### PR TITLE
fix: Broaden try clause to catch all HTTP request exceptions

### DIFF
--- a/repo_health/check_readme.py
+++ b/repo_health/check_readme.py
@@ -124,7 +124,7 @@ def check_readme_links(readme, all_results):
             continue
         try:
             resp = requests.head(url, allow_redirects=True)
-        except requests.ConnectionError as e:
+        except requests.RequestException as e:
             bad.append(f"{url}: {e}")
             continue
 


### PR DESCRIPTION
Context: We just observed a `TooManyRedirects` failure in a repo.