### PR TITLE
chore: Fix some pycodestyle issues that weren't being checked

### DIFF
--- a/repo_health/check_existence.py
+++ b/repo_health/check_existence.py
@@ -34,6 +34,7 @@ req_paths = [
     (".github/workflows/commitlint.yml", "commitlint.yml", "GitHub Action to check conventional commits"),
 ]
 
+
 @health_metadata(
     [module_dict_key],
     req_files
@@ -64,7 +65,7 @@ def check_dir_existence(repo_path, all_results):
 
 @health_metadata(
     [module_dict_key],
-    { key: desc for _, key, desc in req_paths },
+    {key: desc for _, key, desc in req_paths},
 )
 def check_path_existence(repo_path, all_results):
     """

--- a/repo_health/check_makefile.py
+++ b/repo_health/check_makefile.py
@@ -18,7 +18,7 @@ output_keys = {
     "quality-js": "target that runs javascript code quality checks",
     "test-python": "target that runs python unit tests",
     "quality-python": "target that runs python code quality checks",
-    }
+}
 
 
 @pytest.fixture(name='makefile')

--- a/repo_health/check_ownership.py
+++ b/repo_health/check_ownership.py
@@ -64,8 +64,10 @@ def check_ownership(all_results, git_origin_url):
         spreadsheet_url = os.environ[REPO_HEALTH_SHEET_URL]
         worksheet_id = int(os.environ[REPO_HEALTH_WORKSHEET])
     except KeyError:
-        logger.error("At least one of the following REPO_HEALTH_* environment variables is missing\n {} \n {} \n {}"  # pylint: disable=consider-using-f-string
-                     .format(GOOGLE_CREDENTIALS, REPO_HEALTH_SHEET_URL, REPO_HEALTH_WORKSHEET))
+        logger.error(
+            "At least one of the following REPO_HEALTH_* environment variables is missing:\n %s \n %s \n %s",
+            GOOGLE_CREDENTIALS, REPO_HEALTH_SHEET_URL, REPO_HEALTH_WORKSHEET
+        )
         pytest.skip("At least one of the REPO_HEALTH_* environment variables is missing")
 
     match = re.search(URL_PATTERN, git_origin_url)

--- a/repo_health/check_readme.py
+++ b/repo_health/check_readme.py
@@ -84,6 +84,7 @@ EXAMPLE_DOMAINS = {
 # If a URL has any weird meta-characters, it's not a real URL.
 METACHARACTERS = r"[\[\]]"
 
+
 def is_example_url(url):
     """
     Is this URL just an example, no need to check it?
@@ -97,6 +98,7 @@ def is_example_url(url):
         if domain.startswith(".") and parts.hostname.endswith(domain):
             return True
     return False
+
 
 @health_metadata(
     [module_dict_key],

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -58,7 +58,7 @@ def get_docker_file_content(repo_path):
         if fir and sec:  # no need to iterate after getting req data.
             break
 
-    ignored_list = ['chmod',  '/usr/local/bin/gosu', '-qqy', '/usr/bin/python3', '/usr/bin/pip', 'then', '-sf']
+    ignored_list = ['chmod', '/usr/local/bin/gosu', '-qqy', '/usr/bin/python3', '/usr/bin/pip', 'then', '-sf']
     return list({item for sublist in lists for item in sublist if item not in ignored_list and len(item) > 2})
 
 

--- a/repo_health_dashboard/repo_health_dashboard.py
+++ b/repo_health_dashboard/repo_health_dashboard.py
@@ -57,7 +57,7 @@ def main():
     files = glob.glob(os.path.join(data_dir, "*.yaml"), recursive=False)
     data = {}
     for file_path in files:
-        file_name = file_path[file_path.rfind("/") + 1 :]
+        file_name = file_path[file_path.rfind("/") + 1:]
         repo_name = file_name.replace("_repo_health.yaml", "")
         # TODO(jinder): maybe add a try block here
         with codecs.open(file_path, "r", "utf-8") as f:

--- a/repo_health_dashboard/utils/utils.py
+++ b/repo_health_dashboard/utils/utils.py
@@ -165,7 +165,7 @@ def write_squashed_metadata_to_html(metadata_by_repo=None, filename="dashboard.h
         f.write("""  <tr>\n""")
         f.write("""    <th scope="col">Repository</th>\n""")
         for k in sorted_key_tuples:
-            f.write("""    <th scope="col">%s</th>\n""" % html.escape(k))  # pylint: disable=consider-using-f-string
+            f.write(f"""    <th scope="col">{html.escape(k)}</th>\n""")
         f.write("  </tr>\n")
         f.write("</thead>\n")
 
@@ -173,9 +173,9 @@ def write_squashed_metadata_to_html(metadata_by_repo=None, filename="dashboard.h
         # TODO(timmc): Sort rows by repo name
         for dict_name, item in metadata_by_repo.items():
             f.write("  <tr>\n")
-            f.write("""    <th scope="row">%s</th>\n""" % html.escape(dict_name))  # pylint: disable=consider-using-f-string
+            f.write(f"""    <th scope="row">{html.escape(dict_name)}</th>\n""")
             for k in sorted_key_tuples:
-                f.write("""    <td><pre>%s</pre></td>\n""" % html.escape(str(item[k])))  # pylint: disable=consider-using-f-string
+                f.write(f"""    <td><pre>{html.escape(str(item[k]))}</pre></td>\n""")
             f.write("  </tr>\n")
         f.write("</tbody>\n")
         f.write("</table>\n")


### PR DESCRIPTION
Actually enabling it -- and synchronizing the settings with the cookie
cutter and/or edx-lint -- ended up being more of a rabbit hole than I
wanted to go down today. So this just fixes most of it and leaves some
line-length and line-break-near-binary-operator reports unresolved.