### PR TITLE
fix: Don't blow up on uninitialized repo

### DIFF
--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -103,7 +103,10 @@ async def check_build_duration(all_results, github_repo):
     }
 
     data = await client.request(json=_json)
-    total_duration, checks_list = parse_build_duration_response(data)
+    parsed = parse_build_duration_response(data)
+    if parsed is None:  # uninitialized repo
+        return
+    total_duration, checks_list = parsed
 
     all_results[MODULE_DICT_KEY]['build_details'] = json.dumps({
         'total_duration': total_duration,

--- a/repo_health/utils.py
+++ b/repo_health/utils.py
@@ -37,7 +37,7 @@ def parse_build_duration_response(json_response):
     except TypeError:
         return None
 
-    if latest_commits is None or len(latest_commits) == 0:
+    if not latest_commits:
         return None
     else:
         latest_commit = latest_commits[0]

--- a/repo_health/utils.py
+++ b/repo_health/utils.py
@@ -21,15 +21,26 @@ def dir_exists(repo_path, dir_name):
 
 def parse_build_duration_response(json_response):
     """
-    This function is responsible for parsing Github GraphQL API response and calculating build duration
+    This function is responsible for parsing Github GraphQL API response and calculating build duration.
+
+    Returns None when repo is uninitialized.
     """
     build_checks = []
     first_started_at = None
     last_completed_at = None
     total_duration = ''
 
-    latest_commit = functools.reduce(
-        operator.getitem, ["node", "defaultBranchRef", "target", "history", "edges"], json_response)[0]
+    # Handle uninitialized repos (missing default branch, or no commits on branch)
+    try:
+        latest_commits = functools.reduce(
+            operator.getitem, ["node", "defaultBranchRef", "target", "history", "edges"], json_response)
+    except TypeError:
+        return None
+
+    if latest_commits is None or len(latest_commits) == 0:
+        return None
+    else:
+        latest_commit = latest_commits[0]
 
     for check_suite in functools.reduce(operator.getitem, ['node', 'checkSuites', 'edges'], latest_commit):
 


### PR DESCRIPTION
The build durations checker was raising an exception when trying to
look up information on recent builds in a repo that hadn't yet had its
default branch created. (For reference, the JSON response looked like
this: `{'node': {'defaultBranchRef': None}}`.)

- Cancel check when default branch missing
- Cancel check when no commits on branch
