### PR TITLE
fix: add gspread<5.2.0 constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,8 +42,10 @@ google-auth==2.6.0
     #   gspread
 google-auth-oauthlib==0.5.0
     # via gspread
-gspread==5.2.0
-    # via -r requirements/base.in
+gspread==5.1.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 idna==3.3
     # via
     #   requests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -42,5 +42,5 @@ tox==3.24.5
     # via -r requirements/ci.in
 urllib3==1.26.8
     # via requests
-virtualenv==20.13.2
+virtualenv==20.13.3
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,3 +11,10 @@
 
 # This file contains all common constraints for edx-repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+
+# gspread 5.2.0 introduced a backward-incompatible change related to a sheet with
+# extra columns with blank headers. For details of the bug, see
+# https://github.com/burnash/gspread/issues/1007. We can upgrade once the issue is resolved,
+# or if we delete these extra columns. Note: For edX specific ownership spreadsheet, this
+# sheet currently contains a pivot table that would need to be moved elsewhere.
+gspread<5.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -115,8 +115,10 @@ google-auth-oauthlib==0.5.0
     # via
     #   -r requirements/quality.txt
     #   gspread
-gspread==5.2.0
-    # via -r requirements/quality.txt
+gspread==5.1.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
 idna==3.3
     # via
     #   -r requirements/ci.txt
@@ -275,7 +277,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/quality.txt
     #   google-auth-oauthlib
-responses==0.18.0
+responses==0.19.0
     # via -r requirements/quality.txt
 rsa==4.8
     # via
@@ -339,7 +341,7 @@ urllib3==1.26.8
     #   -r requirements/quality.txt
     #   requests
     #   responses
-virtualenv==20.13.2
+virtualenv==20.13.3
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -81,8 +81,10 @@ google-auth-oauthlib==0.5.0
     # via
     #   -r requirements/test.txt
     #   gspread
-gspread==5.2.0
-    # via -r requirements/test.txt
+gspread==5.1.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 idna==3.3
     # via
     #   -r requirements/test.txt
@@ -168,7 +170,7 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   pytest-repo-health
-readme-renderer==32.0
+readme-renderer==33.0
     # via -r requirements/doc.in
 requests==2.27.1
     # via
@@ -180,7 +182,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   google-auth-oauthlib
-responses==0.18.0
+responses==0.19.0
     # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.0.3
+pip==22.0.4
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -86,8 +86,10 @@ google-auth-oauthlib==0.5.0
     # via
     #   -r requirements/test.txt
     #   gspread
-gspread==5.2.0
-    # via -r requirements/test.txt
+gspread==5.1.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 idna==3.3
     # via
     #   -r requirements/test.txt
@@ -202,7 +204,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   google-auth-oauthlib
-responses==0.18.0
+responses==0.19.0
     # via -r requirements/test.txt
 rsa==4.8
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -63,8 +63,10 @@ google-auth-oauthlib==0.5.0
     # via
     #   -r requirements/base.txt
     #   gspread
-gspread==5.2.0
-    # via -r requirements/base.txt
+gspread==5.1.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 idna==3.3
     # via
     #   -r requirements/base.txt
@@ -140,7 +142,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   google-auth-oauthlib
-responses==0.18.0
+responses==0.19.0
     # via -r requirements/test.in
 rsa==4.8
     # via


### PR DESCRIPTION
gspread 5.2.0 introduced a backward-incompatible change related
to a sheet with extra columns with blank headers. For details
of the bug, see https://github.com/burnash/gspread/issues/1007.
We can upgrade once the issue is resolved, or if we delete these
extra columns. Note: For edX specific ownership spreadsheet, this
sheet currently contains a pivot table that would need to be
moved elsewhere.