### PR TITLE
fix: check errors when fetching from ReadTheDocs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+0.2.2 - 2022-03-11
+~~~~~~~~~~~~~~~~~~
+
+Fixed
++++++
+
+* Check the response status code when fetching from ReadTheDocs.
+* Only fetch the project list once from ReadTheDocs, since it's a constant.
+
 [0.2.1] - 2022-03-07
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -25,11 +25,18 @@ Usage
 -----
 
 - Follow Installation steps above
+
 - cd into the directory you wish to run checks on
-- Export ``GITHUB_TOKEN`` into environment, containing Github personal API token with read access to edx org
+
+- Set credentials:
+
+  - Export ``GITHUB_TOKEN`` into environment, containing GitHub personal API token with read access to edx org.
+  - Export ``READTHEDOCS_API_KEY`` into the environment, with a Read The Docs API token.
+  - Note: a ~/.netrc file will override these settings and may interfere. You can use ``NETRC=/dev/null`` to hide the file if needed.
+
 - Run the ``run_checks`` command
 
-  ``run_checks`` is a CLI wrapper around pytest and pytest-repo-health_. Running ``run_checks`` will run all checks located in edx-repo-health repo on the directory you are currently cd'd into.
+  ``run_checks`` is a CLI wrapper around pytest and pytest-repo-health_. Running ``run_checks`` will run all checks located in edx-repo-health repo on the directory you are currently cd'd into.  The results will be written into a repo_health.yaml file.
 
   If you would like to add further flags to the pytest call, you can add the flags after ``run_checks`` command and they will be passed on the pytest automatically. Find out about additional options at pytest-repo-health_ or run ``pytest --help`` command.
 

--- a/repo_health/check_docs.py
+++ b/repo_health/check_docs.py
@@ -1,5 +1,5 @@
 """
-Check some details in the readme file.
+Check some details of Read The Docs integration.
 """
 import json
 import logging
@@ -27,7 +27,7 @@ module_dict_key = "docs"
 )
 def check_build_bagde(readme, all_results):
     """
-    Check that the README file has docs build badge.
+    Check that the README file has a docs build badge.
     """
     if readme is None:
         return
@@ -40,7 +40,7 @@ def check_build_bagde(readme, all_results):
 
 class ReadTheDocsChecker:
     """
-    Handles all the operations related to Read the Docs checks
+    Handles all the operations related to Read the Docs checks.
     """
 
     def __init__(self, repo_path=None, git_origin_url=None, token=None):
@@ -61,7 +61,7 @@ class ReadTheDocsChecker:
 
     def _parse_readthedocs_yml_file(self):
         """
-            Pareses the .readthdocs.yml file and returns parsed data
+        Parses the .readthdocs.yml file and returns parsed data.
         """
         readthedocs_yml = self._read_readthedocs_yml_file()
         try:
@@ -73,7 +73,7 @@ class ReadTheDocsChecker:
 
     def _get_projects(self):
         """
-            Lists all the projects related to the provided token
+        Lists all the projects related to the provided token.
         """
         if self._projects is not None:
             return self._projects
@@ -83,7 +83,7 @@ class ReadTheDocsChecker:
 
     def _get_all_builds(self, slug):
         """
-            Returns all builds details for the project whose slug is provided
+        Returns all build details for the project whose slug is provided.
         """
         build_url = f"https://readthedocs.org/api/v3/projects/{slug}/builds/"
         response = requests.get(build_url, headers=self._headers)
@@ -92,7 +92,7 @@ class ReadTheDocsChecker:
 
     def get_python_version(self):
         """
-            Returns the version of python mentioned in .readthedocs.yml
+        Returns the version of Python mentioned in .readthedocs.yml file.
         """
         parsed_data = self._parse_readthedocs_yml_file()
         if "python" in parsed_data.keys():
@@ -102,7 +102,7 @@ class ReadTheDocsChecker:
 
     def update_build_details(self):
         """
-            Updates the status of latest Read the Docs build and when last built ran
+        Updates the status of latest Read the Docs build and when last build ran.
         """
         self.build_details = []
 
@@ -122,12 +122,12 @@ class ReadTheDocsChecker:
 @health_metadata(
     [module_dict_key],
     {
-        "python_version": "The version of python mentioned in .readthedocs.yml file"
+        "python_version": "The version of Python mentioned in .readthedocs.yml file"
     }
 )
 def check_python_version(repo_path, all_results):
     """
-    Check that the Python version mentioned in .readthedocs.yml file.
+    Check the Python version mentioned in .readthedocs.yml file.
     """
     rtd_checker = ReadTheDocsChecker(repo_path=repo_path)
     all_results[module_dict_key]["python_version"] = rtd_checker.get_python_version()
@@ -136,12 +136,12 @@ def check_python_version(repo_path, all_results):
 @health_metadata(
     [module_dict_key],
     {
-        "build_details": "This contains the build details of all Read the Docs projects connected with that repo",
+        "build_details": "This contains the build details of all Read the Docs projects connected with the repo",
     }
 )
 def check_readthedocs_build(all_results, git_origin_url):
     """
-    Checks Read the Docs build status and when last built ran
+    Checks the Read the Docs build status and when last build ran.
     """
     try:
         token = os.environ["READTHEDOCS_API_KEY"]


### PR DESCRIPTION
**Description:**

This adds error checking to the projects list fetching.  It also only fetches it once, since it's a constant URL.  This might reduce the flaky error we saw.

**Merge checklist:**
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
