### PR TITLE
chore: upgrade to gspread with fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-0.2.2 - 2022-03-11
+[0.2.3] - 2022-04-12
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
++++++++
+
+* Removed gspread constraint to pick up fix in gspread 5.2.3.
+
+[0.2.2] - 2022-03-11
 ~~~~~~~~~~~~~~~~~~
 
 Fixed

--- a/repo_health/__init__.py
+++ b/repo_health/__init__.py
@@ -8,7 +8,7 @@ import glob
 import pytest
 import dockerfile
 
-__version__ = "0.2.0"
+__version__ = "0.2.3"
 
 
 GITHUB_URL_PATTERN = r"github.com[/:](?P<org_name>[^/]+)/(?P<repo_name>[^/]+).*#egg=(?P<package>[^\/]+).*"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,10 +42,8 @@ google-auth==2.6.3
     #   gspread
 google-auth-oauthlib==0.5.1
     # via gspread
-gspread==5.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+gspread==5.3.2
+    # via -r requirements/base.in
 idna==3.3
     # via
     #   requests
@@ -70,7 +68,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pyparsing==3.0.7
+pyparsing==3.0.8
     # via packaging
 pytest==7.1.1
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -28,7 +28,7 @@ pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.7
+pyparsing==3.0.8
     # via packaging
 requests==2.27.1
     # via codecov
@@ -38,9 +38,9 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.5
+tox==3.25.0
     # via -r requirements/ci.in
 urllib3==1.26.9
     # via requests
-virtualenv==20.14.0
+virtualenv==20.14.1
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,10 +11,3 @@
 
 # This file contains all common constraints for edx-repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-# gspread 5.2.0 introduced a backward-incompatible change related to a sheet with
-# extra columns with blank headers. For details of the bug, see
-# https://github.com/burnash/gspread/issues/1007. We can upgrade once the issue is resolved,
-# or if we delete these extra columns. Note: For edX specific ownership spreadsheet, this
-# sheet currently contains a pivot table that would need to be moved elsewhere.
-gspread<5.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -82,7 +82,7 @@ distlib==0.3.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.12
+django==3.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -119,10 +119,8 @@ google-auth-oauthlib==0.5.1
     # via
     #   -r requirements/quality.txt
     #   gspread
-gspread==5.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/quality.txt
+gspread==5.3.2
+    # via -r requirements/quality.txt
 idna==3.3
     # via
     #   -r requirements/ci.txt
@@ -233,7 +231,7 @@ pylint-plugin-utils==0.7
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.7
+pyparsing==3.0.8
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -327,7 +325,7 @@ tomli==2.0.1
     #   pep517
     #   pylint
     #   pytest
-tox==3.24.5
+tox==3.25.0
     # via
     #   -r requirements/ci.txt
     #   tox-battery
@@ -344,7 +342,7 @@ urllib3==1.26.9
     #   -r requirements/quality.txt
     #   requests
     #   responses
-virtualenv==20.14.0
+virtualenv==20.14.1
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -81,10 +81,8 @@ google-auth-oauthlib==0.5.1
     # via
     #   -r requirements/test.txt
     #   gspread
-gspread==5.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+gspread==5.3.2
+    # via -r requirements/test.txt
 idna==3.3
     # via
     #   -r requirements/test.txt
@@ -140,7 +138,7 @@ pygments==2.11.2
     #   doc8
     #   readme-renderer
     #   sphinx
-pyparsing==3.0.7
+pyparsing==3.0.8
     # via
     #   -r requirements/test.txt
     #   packaging

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -56,7 +56,7 @@ coverage[toml]==6.3.2
     #   pytest-cov
 dill==0.3.4
     # via pylint
-django==3.2.12
+django==3.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.in
@@ -88,10 +88,8 @@ google-auth-oauthlib==0.5.1
     # via
     #   -r requirements/test.txt
     #   gspread
-gspread==5.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+gspread==5.3.2
+    # via -r requirements/test.txt
 idna==3.3
     # via
     #   -r requirements/test.txt
@@ -165,7 +163,7 @@ pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.7
+pyparsing==3.0.8
     # via
     #   -r requirements/test.txt
     #   packaging

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -63,10 +63,8 @@ google-auth-oauthlib==0.5.1
     # via
     #   -r requirements/base.txt
     #   gspread
-gspread==5.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+gspread==5.3.2
+    # via -r requirements/base.txt
 idna==3.3
     # via
     #   -r requirements/base.txt
@@ -106,7 +104,7 @@ pyasn1-modules==0.2.8
     # via
     #   -r requirements/base.txt
     #   google-auth
-pyparsing==3.0.7
+pyparsing==3.0.8
     # via
     #   -r requirements/base.txt
     #   packaging


### PR DESCRIPTION
**Description:**

The dependency gspread had a backward incompatibility
introduced in 5.3 which was fixed in 5.3.2, so this
removes the constraint and upgrades gspread.

**Merge checklist:**
- [X] Changelog record added
- [X] Documentation updated (not only docstrings)
- [ ] Commits are squashed
