### PR TITLE
feat: Added check to verify pip.txt installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.2.4] - 2022-05-23
+~~~~~~~~~~~~~~~~~~~~
+
+Added
++++++++
+
+* Added a check to validate that pip.txt requirements are installed immediately after upgrading pip.txt in Makefile's upgrade target
+
 [0.2.3] - 2022-04-12
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/repo_health/__init__.py
+++ b/repo_health/__init__.py
@@ -8,7 +8,7 @@ import glob
 import pytest
 import dockerfile
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 
 GITHUB_URL_PATTERN = r"github.com[/:](?P<org_name>[^/]+)/(?P<repo_name>[^/]+).*#egg=(?P<package>[^\/]+).*"

--- a/tests/fake_repos/makefile_repo2/Makefile
+++ b/tests/fake_repos/makefile_repo2/Makefile
@@ -18,7 +18,10 @@ piptools:
 
 export CUSTOM_COMPILE_COMMAND = make upgrade
 upgrade: piptools ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
-	pip-compile --rebuild --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
+	pip-compile --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip-compile --allow-unsafe --rebuild --upgrade -o requirements/pip.txt requirements/pip.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --rebuild --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --rebuild --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --rebuild --upgrade -o requirements/docs.txt requirements/docs.in

--- a/tests/test_check_makefile.py
+++ b/tests/test_check_makefile.py
@@ -4,6 +4,7 @@ import pytest
 from repo_health.check_makefile import (
     module_dict_key,
     check_has_make_target,
+    check_upgrade_script,
     output_keys,
 )
 
@@ -41,3 +42,18 @@ def test_check_file_existence(fake_repo, flag_list):
 
     for key, desc in output_keys.items():
         assert all_results[module_dict_key][key] == flag_list[key]
+
+
+@pytest.mark.parametrize("fake_repo, flag", [
+    ("makefile_repo1",
+    {"pip-installed": False
+    }),
+    ("makefile_repo2",
+    {"pip-installed": True
+    })])
+def test_check_upgrade_script(fake_repo, flag):
+    repo_path = get_repo_path('fake_repos/' + fake_repo)
+    all_results = {module_dict_key: {}}
+    file = open(repo_path + '/Makefile', 'r')
+    check_upgrade_script(file.read(), all_results)
+    assert all_results[module_dict_key]["pip-installed"] == flag["pip-installed"]


### PR DESCRIPTION
This check verifies that we are installing pip immediately after upgrading it.
pip should be installed after the upgrade to ensure that new pip version is compatible with installed pip-tools version.

JIRA: https://2u-internal.atlassian.net/browse/BOM-3402