### PR TITLE
feat: add checks of url= and project_urls= in Python packaging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,16 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Added
++++++
+
+* Added a check for the url= and project_urls= settings in setup.py and setup.cfg.
+
 [0.2.4] - 2022-05-23
 ~~~~~~~~~~~~~~~~~~~~
 
 Added
-+++++++
++++++
 
 * Added a check to validate that pip.txt requirements are installed immediately after upgrading pip.txt in Makefile's upgrade target
 

--- a/repo_health/check_setup_py.py
+++ b/repo_health/check_setup_py.py
@@ -67,3 +67,30 @@ def check_pypi_name(setup_py, setup_cfg, all_results):
     if names:
         assert len(names) == 1
         all_results[module_dict_key]["pypi_name"] = names[0]
+
+
+@add_key_to_metadata((module_dict_key, "repo_url"))
+def check_repo_url(setup_py, setup_cfg, all_results):
+    """
+    Get the repo URL.
+    """
+    py_urls = re.findall(r"""(?m)^\s*url\s*=\s*['"]([^'"]+)['"]""", setup_py)
+    cfg_urls = re.findall(r"""(?m)^url\s*=\s*(\S+)""", setup_cfg)
+    urls = py_urls + cfg_urls
+    if urls:
+        assert len(urls) == 1
+        all_results[module_dict_key]["repo_url"] = urls[0]
+
+
+@add_key_to_metadata((module_dict_key, "project_urls"))
+def check_project_urls(setup_py, setup_cfg, all_results):
+    """
+    Get the additional project URLs.
+    TODO: This captures the multi-line junk without parsing them out individually.
+    """
+    py_urls = re.findall(r"""(?ms)^\s*project_urls\s*=\s*({[^}]+})""", setup_py)
+    cfg_urls = re.findall(r"""(?ms)^project_urls\s*=\s*(.*?)(?:^\S|^$)""", setup_cfg)
+    urls = py_urls + cfg_urls
+    if urls:
+        assert len(urls) == 1
+        all_results[module_dict_key]["project_urls"] = urls[0]

--- a/tests/fake_repos/just_setup_cfg/setup.cfg
+++ b/tests/fake_repos/just_setup_cfg/setup.cfg
@@ -2,3 +2,7 @@
 name = setup_cfg_package
 version = attr: pkg.__version__
 description = Just a bogus testing package
+url = https://github.com/openedx/just_setup_cfg
+project_urls =
+    Source = https://github.com/openedx/just_setup_py
+    Bugs = https://somebugs.com

--- a/tests/fake_repos/just_setup_py/setup.py
+++ b/tests/fake_repos/just_setup_py/setup.py
@@ -2,4 +2,9 @@ from setuptools import setup
 
 setup(
  name = "some_other_pypi_name",
+ url = "https://github.com/openedx/just_setup_py",
+ project_urls = {
+     "Source": "https://github.com/openedx/just_setup_py",
+     "Bugs": "https://somebugs.com",
+ },
 )

--- a/tests/test_check_setup_py.py
+++ b/tests/test_check_setup_py.py
@@ -3,7 +3,9 @@ from pathlib import Path
 import pytest
 
 from repo_health import get_file_content
-from repo_health.check_setup_py import check_pypi_name, module_dict_key
+from repo_health.check_setup_py import (
+    check_project_urls, check_pypi_name, check_repo_url, module_dict_key,
+)
 
 FAKE_REPO_ROOT = Path(__file__).parent / "fake_repos"
 
@@ -22,3 +24,40 @@ def test_check_pypi_name(fake_repo, pypi_name):
         assert all_results[module_dict_key]["pypi_name"] == pypi_name
     else:
         assert "pypi_name" not in all_results[module_dict_key]
+
+@pytest.mark.parametrize("fake_repo, repo_url", [
+    ("just_setup_py", "https://github.com/openedx/just_setup_py"),
+    ("just_setup_cfg", "https://github.com/openedx/just_setup_cfg"),
+    ("docs_repo", None),
+])
+def test_check_repo_url(fake_repo, repo_url):
+    setup_py = get_file_content(FAKE_REPO_ROOT / fake_repo / "setup.py")
+    setup_cfg = get_file_content(FAKE_REPO_ROOT / fake_repo / "setup.cfg")
+    all_results = {module_dict_key: {}}
+    check_repo_url(setup_py, setup_cfg, all_results)
+    print(all_results)
+    if repo_url is not None:
+        assert all_results[module_dict_key]["repo_url"] == repo_url
+    else:
+        assert "repo_url" not in all_results[module_dict_key]
+
+@pytest.mark.parametrize("fake_repo, project_urls", [
+    (
+        "just_setup_py",
+        '{\n     "Source": "https://github.com/openedx/just_setup_py",\n     "Bugs": "https://somebugs.com",\n }',
+    ),
+    (
+        "just_setup_cfg",
+        'Source = https://github.com/openedx/just_setup_py\n    Bugs = https://somebugs.com\n',
+    ),
+    ("docs_repo", None),
+])
+def test_check_project_urls(fake_repo, project_urls):
+    setup_py = get_file_content(FAKE_REPO_ROOT / fake_repo / "setup.py")
+    setup_cfg = get_file_content(FAKE_REPO_ROOT / fake_repo / "setup.cfg")
+    all_results = {module_dict_key: {}}
+    check_project_urls(setup_py, setup_cfg, all_results)
+    if project_urls is not None:
+        assert all_results[module_dict_key]["project_urls"] == project_urls
+    else:
+        assert "project_urls" not in all_results[module_dict_key]


### PR DESCRIPTION
**Description:**

I discovered that some of our Python packages don't declare the `url=` setting in setup.py.  This checks for that setting.  I also added a check for the `project_urls=` setting while I was there.

**Merge checklist:**
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
