### PR TITLE
test: async tests have to be marked in order to run

### DIFF
--- a/tests/test_check_github.py
+++ b/tests/test_check_github.py
@@ -1,7 +1,8 @@
-#!/usr/bin/env python3
 """Testing functions in repo_health/check_github.py"""
 
 from unittest.mock import Mock
+
+import pytest
 
 from repo_health.check_github import (
     check_settings,
@@ -10,6 +11,7 @@ from repo_health.check_github import (
 )
 
 
+@pytest.mark.asyncio
 async def test_check_settings_license_exemption_present():
     """
     Test to make sure having an exemption in repo_license_exemptions results in change of license in all_results dict
@@ -37,6 +39,7 @@ async def test_check_settings_license_exemption_present():
     assert all_results["github"]["license"] == test_license
 
 
+@pytest.mark.asyncio
 async def test_check_settings_no_license_exemption_present():
     """
     Test to make sure exemptions code does not make any changes when no exemption is present.

--- a/tests/test_check_renovate.py
+++ b/tests/test_check_renovate.py
@@ -1,10 +1,12 @@
 import os
+from unittest import mock, TestCase
+
+import pytest
 
 from repo_health.check_renovate import (
     check_renovate,
     MODULE_DICT_KEY,
 )
-from unittest import mock, TestCase
 
 def get_repo_path(repo_name):
     tests_directory = os.path.dirname(__file__)
@@ -16,6 +18,7 @@ async def mocked_responses(*args, **kwargs):
 
 
 @mock.patch('repo_health.check_renovate.get_last_pull_date')
+@pytest.mark.asyncio
 async def test_check_renovate_true(mock_get):
     mock_get.return_value = await mocked_responses()
     all_results = {MODULE_DICT_KEY: {}}
@@ -24,6 +27,7 @@ async def test_check_renovate_true(mock_get):
     assert all_results[MODULE_DICT_KEY]['configured'] == True
 
 @mock.patch('repo_health.check_renovate.get_last_pull_date')
+@pytest.mark.asyncio
 async def test_check_renovate_false(mock_get):
     mock_get.return_value = await mocked_responses()
     all_results = {MODULE_DICT_KEY: {}}


### PR DESCRIPTION
**Description:**

Four tests were being skipped:
```
tests/test_check_github.py::test_check_settings_license_exemption_present
tests/test_check_github.py::test_check_settings_no_license_exemption_present
tests/test_check_renovate.py::test_check_renovate_true
tests/test_check_renovate.py::test_check_renovate_false
  /System/Volumes/Data/root/src/edx/src/edx-repo-health/.tox/py38/lib/python3.8/site-packages/_pytest/python.py:184: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - anyio
    - pytest-asyncio
    - pytest-tornasync
    - pytest-trio
    - pytest-twisted
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))
```

The message here says you need to install a package, but it was already installed.  Missing was the decorator to indicate that the test was async.

**Merge checklist:**
- [x] Changelog record added (not needed)
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
