### PR TITLE
feat: check if a repo wants to be in Open edX but isn't in openedx #338

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Added
 
 * Added a check for the url= and project_urls= settings in setup.py and setup.cfg.
 
+* Added a check for repos that indicate inclusion in Open edX in their openedx.yaml file, but aren't in the openedx GitHub organization.
+
 [0.2.4] - 2022-05-23
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/fake_repos/openedx_repo3/openedx.yaml
+++ b/tests/fake_repos/openedx_repo3/openedx.yaml
@@ -1,0 +1,13 @@
+# This file describes this Open edX repo, as described in OEP-2:
+# http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
+
+nick: test
+oeps:
+    oep-2: true
+    oep-7: false
+    oep-18: true
+openedx-release:
+    ref: master
+tags:
+    - tools
+    - webservice

--- a/tests/test_check_openedx_yaml.py
+++ b/tests/test_check_openedx_yaml.py
@@ -2,17 +2,18 @@ import os
 import pytest
 
 from repo_health.check_openedx_yaml import (
-    check_oeps,
     check_obsolete_fields,
+    check_oeps,
     check_release_maybe,
+    check_release_org_compliance,
     check_release_ref,
     check_yaml_parsable,
-    module_dict_key,
-    fixture_openedx_yaml,
     fixture_oeps,
+    fixture_openedx_yaml,
     fixture_parsed_data,
-    output_keys,
+    module_dict_key,
     obsolete_fields,
+    output_keys,
 )
 
 
@@ -41,6 +42,17 @@ def test_check_release_maybe(parsed_data, result):
     check_release_maybe(parsed_data, all_results)
 
     assert all_results[module_dict_key]['release-maybe'] == result
+
+
+@pytest.mark.parametrize("repo_path, git_origin_url, result", [
+    (get_repo_path("openedx_repo1"), "https://github.com/openedx/openedx_repo1.git", True),
+    (get_repo_path("openedx_repo2"), "https://github.com/openedx/openedx_repo2.git", True),
+    (get_repo_path("openedx_repo3"), "https://github.com/edx/openedx_repo3.git", False),
+])
+def test_check_release_org_compliance(parsed_data, git_origin_url, result):
+    all_results = {module_dict_key:{}}
+    check_release_org_compliance(parsed_data, git_origin_url, all_results)
+    assert all_results[module_dict_key]["release-org-compliance"] == result
 
 
 @pytest.mark.parametrize("repo_path, result", [

--- a/tests/test_check_openedx_yaml.py
+++ b/tests/test_check_openedx_yaml.py
@@ -22,10 +22,9 @@ def get_repo_path(repo_name):
 
 
 @pytest.mark.parametrize("repo_path, result", [
-    (get_repo_path('openedx_repo1'),'master'),
-    (get_repo_path('openedx_repo2'),''),
+    (get_repo_path("openedx_repo1"), "master"),
+    (get_repo_path("openedx_repo2"), ""),
 ])
-
 def test_check_release_ref(parsed_data, result):
     all_results = {module_dict_key:{}}
     check_release_ref(parsed_data, all_results)
@@ -34,10 +33,9 @@ def test_check_release_ref(parsed_data, result):
 
 
 @pytest.mark.parametrize("repo_path, result", [
-    (get_repo_path('openedx_repo1'),True),
-    (get_repo_path('openedx_repo2'),False)
+    (get_repo_path("openedx_repo1"), True),
+    (get_repo_path("openedx_repo2"), False),
 ])
-
 def test_check_release_maybe(parsed_data, result):
     all_results = {module_dict_key:{}}
     check_release_maybe(parsed_data, all_results)
@@ -46,11 +44,10 @@ def test_check_release_maybe(parsed_data, result):
 
 
 @pytest.mark.parametrize("repo_path, result", [
-    (get_repo_path('openedx_repo1'),True),
-    (get_repo_path('openedx_repo2'),True),
-    (get_repo_path('docs_repo'), False),
+    (get_repo_path("openedx_repo1"), True),
+    (get_repo_path("openedx_repo2"), True),
+    (get_repo_path("docs_repo"), False),
 ])
-
 def test_check_yaml_parsable(openedx_yaml, result):
     all_results = {module_dict_key:{}}
     check_yaml_parsable(openedx_yaml, all_results)
@@ -59,20 +56,19 @@ def test_check_yaml_parsable(openedx_yaml, result):
 
 
 @pytest.mark.parametrize("repo_path, result_list", [
-    (get_repo_path('openedx_repo1'),{
+    (get_repo_path("openedx_repo1"), {
         "oep-2":True,
         "oep-7":False,
         "oep-18":True,
         "oep-30":False
     }),
-    (get_repo_path('openedx_repo2'),{
+    (get_repo_path("openedx_repo2"), {
         "oep-2":True,
         "oep-7":True,
         "oep-18":False,
         "oep-30":False
-    })
+    }),
 ])
-
 def test_check_oeps(oeps, result_list):
     all_results = {module_dict_key:{}}
     check_oeps(oeps, all_results)
@@ -82,10 +78,9 @@ def test_check_oeps(oeps, result_list):
 
 
 @pytest.mark.parametrize("repo_path, result_list", [
-    (get_repo_path('openedx_repo1'),['nick']),
-    (get_repo_path('openedx_repo2'),['nick', 'supporting-teams'])
+    (get_repo_path("openedx_repo1"), ["nick"]),
+    (get_repo_path("openedx_repo2"), ["nick", "supporting-teams"]),
 ])
-
 def test_check_obsolete_fields(parsed_data, result_list):
     all_results = {module_dict_key:{}}
     check_obsolete_fields(parsed_data, all_results)


### PR DESCRIPTION
**Description:**

Note repos that indicate inclusion in Open edX but that aren't in the openedx organization.

**Merge checklist:**
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed: I'd rather not: one is purely formatting, the other is substantive.
