### PR TITLE
fix: Use org name in GitHub calls, rather than hardcoded "edx"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 **********
 
+Fixed
+=====
+
+* Use repo's actual org name in GitHub calls, rather than hardcoded "edx"
+
+
 [1.0.0] - 2023-01-02
 ********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 Change Log
-----------
+##########
 
 ..
    All enhancements and patches to edx-repo-health will be documented
@@ -12,11 +12,13 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
-~~~~~~~~~~
+**********
+
 [1.0.0] - 2023-01-02
+********************
 
 Added
-+++++++
+=====
 
 * Added code to generate sqlite database for repo health data.
 * Added a check for the url= and project_urls= settings in setup.py and setup.cfg.
@@ -25,120 +27,120 @@ Added
 * Added a check for repos that indicate inclusion in Open edX in their openedx.yaml file, but aren't in the openedx GitHub organization.
 
 [0.2.4] - 2022-05-23
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Added
-+++++
+=====
 
 * Added a check to validate that pip.txt requirements are installed immediately after upgrading pip.txt in Makefile's upgrade target
 
 [0.2.3] - 2022-04-12
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Changed
-+++++++
+=======
 
 * Removed gspread constraint to pick up fix in gspread 5.2.3.
 
 [0.2.2] - 2022-03-11
-~~~~~~~~~~~~~~~~~~
+********************
 
 Fixed
-+++++
+=====
 
 * Check the response status code when fetching from ReadTheDocs.
 * Only fetch the project list once from ReadTheDocs, since it's a constant.
 
 [0.2.1] - 2022-03-07
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Fixed
-+++++
+=====
 
 * Fix to not have checks blow up on an uninitialized repo.
 * Temporary fix for check_ownership by constraining gspread<5.2.0. See constraints.txt for details, and information on how this constraint could be removed.
 
 [0.2.0] - 2021-11-19
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Fixed
-+++++
+=====
 
 * Fixed code for defining version.
 
 
 [0.1.8] - 2021-10-27
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Added
-+++++
+=====
 
 * Added a check for commitlint.yaml, the GitHub Action check for conformance to
   conventional commits.
 
 [0.1.7] - 2021-06-25
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Added
-+++++
+=====
 
 * Added check to parse ubuntu packages from anisble playbooks.
 
 [0.1.6] - 2021-05-19
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Added
-+++++
+=====
 
 * Added docker file parsing check. Picking apt-get install or update packages.
 
 [0.1.5] - 2021-05-18
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Fixed
-+++++
+=====
 
 * Fixed package-lock.json not found error.
 
 [0.1.4] - 2021-05-18
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Refactor
-++++++++
+========
 
 * pypi_all will show all dependencies in requirements folder.
 * pypi will only show production or development related dependencies.
 
 [0.1.3] - 2021-05-18
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Changed
-+++++++
+=======
 
 * Added all JS dependencies from package-lock.json. Updated tests.
 
 Added
-+++++
+=====
 
 * Added new column for frontend repos to track what npm package name they publish.
 
 [0.1.2] - 2021-05-05
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Changed
-+++++++
+=======
 
 * Added development.txt and dev.txt for picking dependencies. Updated tests.
 
 [0.1.1] - 2021-05-04
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 Added
-+++++
+=====
 
 * Added testing dependencies as separate column.
 
 [0.1.0] - 2020-03-16
-~~~~~~~~~~~~~~~~~~~~
+********************
 
 First release.

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -236,16 +236,16 @@ def check_branch_and_pr_count(all_results, git_origin_url):
     """
     Checks repository integrated with github actions workflow
     """
-    _, repo_name = github_org_repo(git_origin_url)
-    all_results[MODULE_DICT_KEY]['branch_count'] = get_branch_or_pr_count(repo_name, 'branches')
-    all_results[MODULE_DICT_KEY]['pulls_count'] = get_branch_or_pr_count(repo_name, 'pulls')
+    org_name, repo_name = github_org_repo(git_origin_url)
+    all_results[MODULE_DICT_KEY]['branch_count'] = get_branch_or_pr_count(org_name, repo_name, 'branches')
+    all_results[MODULE_DICT_KEY]['pulls_count'] = get_branch_or_pr_count(org_name, repo_name, 'pulls')
 
 
-def get_branch_or_pr_count(repo_name, pulls_or_branches):
+def get_branch_or_pr_count(org_name, repo_name, pulls_or_branches):
     """
     Get the count for branches or pull requests using Github API and add the count to report
     """
-    url = f"https://api.github.com/repos/edx/{repo_name}/{pulls_or_branches}?per_page=1"
+    url = f"https://api.github.com/repos/{org_name}/{repo_name}/{pulls_or_branches}?per_page=1"
     count = 0
 
     response = requests.get(url=url, headers={'Authorization': f'Bearer {os.environ["GITHUB_TOKEN"]}'})

--- a/repo_health/check_github_integration.py
+++ b/repo_health/check_github_integration.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 module_dict_key = "github_actions"
 
 
-def get_githubworkflow_api_response(repo_name):
+def get_githubworkflow_api_response(org_name, repo_name):
     """
     get the workflows information using api.
     """
@@ -24,7 +24,7 @@ def get_githubworkflow_api_response(repo_name):
     # https://developer.github.com/v3/#rate-limiting
 
     return requests.get(
-        url=f'https://api.github.com/repos/edx/{repo_name}/actions/workflows',
+        url=f'https://api.github.com/repos/{org_name}/{repo_name}/actions/workflows',
         headers={'Authorization': f'Bearer {os.environ["GITHUB_TOKEN"]}'}
     )
 
@@ -34,14 +34,15 @@ class GitHubIntegrationHandler:
     sets up the operations and required  github actions workflow CI integration information on instance
     """
 
-    def __init__(self, repo_name):
+    def __init__(self, org_name, repo_name):
+        self.org_name = org_name
         self.repo_name = repo_name
         self.api_data = None
         self.github_actions = False
         self._set_github_actions_integration_data()
 
     def _set_github_actions_integration_data(self):
-        self.api_response = get_githubworkflow_api_response(self.repo_name)
+        self.api_response = get_githubworkflow_api_response(self.org_name, self.repo_name)
 
     def handle(self):
         """
@@ -76,7 +77,7 @@ def check_github_actions_integration(all_results, git_origin_url):
     Checks repository integrated with github actions workflow
     """
     org_name, repo_name = github_org_repo(git_origin_url)
-    integration_handler = GitHubIntegrationHandler(repo_name)
+    integration_handler = GitHubIntegrationHandler(org_name, repo_name)
     integration_handler.handle()
     all_results[module_dict_key] = bool(integration_handler.github_actions)
     all_results['org_name'] = org_name


### PR DESCRIPTION
This probably wasn't affecting repos that had moved from edx to openedx,
but was definitely giving us bad/missing data for newer repos.

This is to address https://github.com/openedx/edx-repo-health/issues/295

There's also a separate commit to fix up the changelog's rST headers.

**Merge checklist:**
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
