### PR TITLE
fix: add check for dependabot alert counts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,11 @@ Fixed
 
 * Use repo's actual org name in GitHub calls, rather than hardcoded "edx"
 
+Added
+=====
+
+* Added a check to determine the amount of dependabot alerts per repo
+
 
 [1.0.0] - 2023-01-02
 ********************

--- a/repo_health/check_dependabot_alerts.py
+++ b/repo_health/check_dependabot_alerts.py
@@ -1,0 +1,86 @@
+"""
+Checks repository open dependabot alert and collects metrics.
+"""
+
+import logging
+import os
+
+import requests
+from pytest_repo_health import health_metadata
+
+from .utils import github_org_repo
+
+logger = logging.getLogger(__name__)
+
+MODULE_DICT_KEY = "dependabot_alerts"
+
+def get_github_dependabot_api_response(org_name, repo_name):
+    """
+    Fetch the repo's list of open Dependabot alerts, as `requests` response object
+    """
+
+    response = requests.get(
+        url=f'https://api.github.com/repos/{org_name}/{repo_name}/dependabot/alerts?state=open&per_page=100',
+        headers={'Authorization': f'Bearer {os.environ["GITHUB_TOKEN"]}'}
+    )
+
+    if response.status_code != 200:
+        logger.error(
+                "An error occurred while fetching %s. status code %s content info %s.",
+                repo_name,
+                response.status_code,
+                response.content
+        )
+        return None
+
+    return response
+
+@health_metadata(
+    [MODULE_DICT_KEY, "dependabot_alerts"],
+    {
+        "total_count": "The total number of open Dependabot alerts for this repository",
+        "low_severity ": "Open Dependabot alerts with low severity",
+        "medium_severity ": "Open Dependabot alerts with medium severity",
+        "high_severity ": "Open Dependabot alerts with high severity",
+        "critical_severity ": "Open Dependabot alerts with critical severity",
+        "incomplete_results": "Indicates if there are additional open alerts beyond the page count limit of 100"
+    }
+)
+def check_dependabot_alert_stats(all_results, git_origin_url):
+    """
+    Checks repo stats for dependabot alerts
+    """
+    org_name, repo_name = github_org_repo(git_origin_url)
+    stats = compile_dependabot_stats(org_name, repo_name)
+
+    all_results[MODULE_DICT_KEY] = stats
+
+def compile_dependabot_stats(org_name, repo_name):
+    """
+    Compiles dependabot alert stats for the repo
+    """
+    response = get_github_dependabot_api_response(org_name, repo_name)
+    if response is None:
+        return {}
+    else:
+        stat_dict = {
+            "total_count": 0,
+            "critical_severity": 0,
+            "high_severity": 0,
+            "medium_severity": 0,
+            "low_severity": 0,
+        }
+        dependabot_alerts = response.json()
+        for dependabot_alert in dependabot_alerts:
+            stat_dict["total_count"] += 1
+
+            if dependabot_alert["security_vulnerability"]["severity"] == "low":
+                stat_dict["low_severity"] += 1
+            elif dependabot_alert["security_vulnerability"]["severity"] == "medium":
+                stat_dict["medium_severity"] += 1
+            elif dependabot_alert["security_vulnerability"]["severity"] == "high":
+                stat_dict["high_severity"] += 1
+            elif dependabot_alert["security_vulnerability"]["severity"] == "critical":
+                stat_dict["critical_severity"] += 1
+        stat_dict['incomplete_results'] = 'next' in response.links
+        return stat_dict

--- a/tests/data/github_dependabot_alerts_no_links.json
+++ b/tests/data/github_dependabot_alerts_no_links.json
@@ -1,0 +1,19 @@
+{
+  "content": [
+    {
+      "number": 6,
+      "state": "open",
+      "security_vulnerability": {
+        "severity": "critical"
+      }
+    },
+    {
+      "number": 5,
+      "state": "open",
+      "security_vulnerability": {
+        "severity": "high"
+      }
+    }
+  ],
+  "links": {}
+}

--- a/tests/data/github_dependabot_alerts_with_links.json
+++ b/tests/data/github_dependabot_alerts_with_links.json
@@ -1,0 +1,35 @@
+{
+  "content": [
+    {
+      "number": 6,
+      "state": "open",
+      "security_vulnerability": {
+        "severity": "critical"
+      }
+    },
+    {
+      "number": 5,
+      "state": "open",
+      "security_vulnerability": {
+        "severity": "low"
+      }
+    },
+    {
+      "number": 13,
+      "state": "open",
+      "security_vulnerability": {
+        "severity": "medium"
+      }
+    }
+  ],
+  "links": {
+    "next": {
+      "url":"https://api.github.com/repo/openedx/dependabot-test/dependabot/alerts?state=open&per_page=10&page=2",
+      "rel": "next"
+    },
+    "last": {
+      "url":"https://api.github.com/repo/openedx/dependabot-test/dependabot/alerts?state=open&per_page=10&page=9",
+      "rel": "last"
+    }
+  }
+}

--- a/tests/test_check_dependabot_alerts.py
+++ b/tests/test_check_dependabot_alerts.py
@@ -1,0 +1,77 @@
+"""Test suite for dependabot alerts check"""
+import json
+import os
+from unittest import mock
+
+from repo_health.check_dependabot_alerts import MODULE_DICT_KEY, check_dependabot_alert_stats
+
+
+class MockResponse:
+    """
+    Class to hold mock responses from api call
+    """
+    def __init__(self, response, status_code):
+        self.content = response["content"]
+        self.status_code = status_code
+        self.links = response["links"]
+
+    def json(self):
+        return self.content
+
+
+def mocked_responses(*args, **kwargs):
+    # pylint: disable=line-too-long
+    """
+    Produces a MockResponse object based on the passed in URL
+    """
+    current_dir = os.path.dirname(__file__)
+
+    if kwargs['url'] == 'https://api.github.com/repos/edx/dependabot-test/dependabot/alerts?state=open&per_page=100':
+        with open(os.path.join(current_dir, 'data/github_dependabot_alerts_with_links.json'), 'r') as read_file:
+            dependabot_data = json.load(read_file)
+            return MockResponse(dependabot_data, 200)
+    elif kwargs['url'] == 'https://api.github.com/repos/openedx/dependabot-test/dependabot/alerts?state=open&per_page=100':
+        with open(os.path.join(current_dir, 'data/github_dependabot_alerts_no_links.json'), 'r') as read_file:
+            dependabot_data = json.load(read_file)
+            return MockResponse(dependabot_data, 200)
+    return MockResponse(None, 404)
+
+
+@mock.patch('repo_health.check_dependabot_alerts.get_github_dependabot_api_response')
+def test_check_dependabot_alerts_edx(mock_get):
+    """
+    Test to check if incomplete results is true and if counts are accurate
+    Incomplete results designates that number of alerts is greater than alerts per page
+    In this case, alerts per page is 100, the max
+    """
+    # pylint: disable=line-too-long
+    mock_get.return_value = mocked_responses(url='https://api.github.com/repos/edx/dependabot-test/dependabot/alerts?state=open&per_page=100')
+
+    all_results = {MODULE_DICT_KEY: {}}
+    check_dependabot_alert_stats(all_results, git_origin_url='github.com/edx/dependabot-test.git')
+
+    assert all_results[MODULE_DICT_KEY]
+    assert all_results[MODULE_DICT_KEY]['total_count'] == 3
+    assert all_results[MODULE_DICT_KEY]['critical_severity'] == 1
+    assert all_results[MODULE_DICT_KEY]['low_severity'] == 1
+    assert all_results[MODULE_DICT_KEY]['medium_severity'] == 1
+    assert 'incomplete_results' in all_results[MODULE_DICT_KEY]
+    assert all_results[MODULE_DICT_KEY]['incomplete_results'] is True
+
+@mock.patch('repo_health.check_dependabot_alerts.get_github_dependabot_api_response')
+def test_check_dependabot_alerts_openedx(mock_get):
+    """
+    Test to check if incomplete results is false and if counts are accurate
+    """
+    # pylint: disable=line-too-long
+    mock_get.return_value = mocked_responses(url='https://api.github.com/repos/openedx/dependabot-test/dependabot/alerts?state=open&per_page=100')
+
+    all_results = {MODULE_DICT_KEY: {}}
+    check_dependabot_alert_stats(all_results, git_origin_url='github.com/openedx/dependabot-test.git')
+
+    assert all_results[MODULE_DICT_KEY]
+    assert all_results[MODULE_DICT_KEY]['total_count'] == 2
+    assert all_results[MODULE_DICT_KEY]['critical_severity'] == 1
+    assert all_results[MODULE_DICT_KEY]['high_severity'] == 1
+    assert 'incomplete_results' in all_results[MODULE_DICT_KEY]
+    assert all_results[MODULE_DICT_KEY]['incomplete_results'] is False


### PR DESCRIPTION
**Description:**

For [SEG-78](https://2u-internal.atlassian.net/browse/SEG-78) to add a dependabot check for edx-repo health.

Check adds total counts of open dependabot alerts, and breaks it down into individual low, medium, high, and critical severity counts

**Merge checklist:**
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
