### PR TITLE
fix: Remove codecov dependency.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixed
 =====
 
 * Use repo's actual org name in GitHub calls, rather than hardcoded "edx"
+* Remove codecov dependency.
 
 Added
 =====

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,9 +13,7 @@ aiosignal==1.3.1
 async-timeout==4.0.2
     # via aiohttp
 attrs==22.2.0
-    # via
-    #   aiohttp
-    #   pytest
+    # via aiohttp
 cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
@@ -38,13 +36,13 @@ github.py @ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f
     # via -r requirements/github.in
 gitpython==3.1.31
     # via pytest-repo-health
-google-auth==2.17.0
+google-auth==2.17.3
     # via
     #   google-auth-oauthlib
     #   gspread
 google-auth-oauthlib==1.0.0
     # via gspread
-gspread==5.7.2
+gspread==5.8.0
     # via -r requirements/base.in
 idna==3.4
     # via
@@ -72,7 +70,7 @@ pyasn1-modules==0.2.8
     # via google-auth
 pyparsing==3.0.9
     # via packaging
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   pytest-aiohttp
     #   pytest-asyncio

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests in Travis
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,22 +4,12 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
-    # via requests
-charset-normalizer==3.1.0
-    # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
-coverage==7.2.2
-    # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.10.7
+filelock==3.11.0
     # via
     #   tox
     #   virtualenv
-idna==3.4
-    # via requests
 packaging==21.3
     # via
     #   -c requirements/constraints.txt
@@ -32,8 +22,6 @@ py==1.11.0
     # via tox
 pyparsing==3.0.9
     # via packaging
-requests==2.28.2
-    # via codecov
 six==1.16.0
     # via tox
 tomli==2.0.1
@@ -42,7 +30,5 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
-urllib3==1.26.15
-    # via requests
 virtualenv==20.21.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.1
+astroid==2.15.2
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -30,7 +30,6 @@ attrs==22.2.0
     # via
     #   -r requirements/quality.txt
     #   aiohttp
-    #   pytest
 build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
@@ -41,14 +40,12 @@ cachetools==5.3.0
     #   google-auth
 certifi==2022.12.7
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
 chardet==5.1.0
     # via diff-cover
 charset-normalizer==3.1.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   aiohttp
     #   requests
@@ -68,13 +65,9 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
 diff-cover==7.5.0
     # via -r requirements/dev.in
@@ -98,7 +91,7 @@ exceptiongroup==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-filelock==3.10.7
+filelock==3.11.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -118,7 +111,7 @@ gitpython==3.1.31
     # via
     #   -r requirements/quality.txt
     #   pytest-repo-health
-google-auth==2.17.0
+google-auth==2.17.3
     # via
     #   -r requirements/quality.txt
     #   google-auth-oauthlib
@@ -127,11 +120,10 @@ google-auth-oauthlib==1.0.0
     # via
     #   -r requirements/quality.txt
     #   gspread
-gspread==5.7.2
+gspread==5.8.0
     # via -r requirements/quality.txt
 idna==3.4
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
     #   yarl
@@ -182,7 +174,7 @@ pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
 platformdirs==3.2.0
     # via
@@ -214,9 +206,9 @@ pycodestyle==2.10.0
     # via -r requirements/quality.txt
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.14.0
+pygments==2.15.0
     # via diff-cover
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -246,7 +238,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/quality.txt
     #   pytest-aiohttp
@@ -281,9 +273,7 @@ pyyaml==6.0
     #   responses
 requests==2.28.2
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   codecov
     #   requests-oauthlib
     #   responses
 requests-oauthlib==1.3.1
@@ -356,7 +346,6 @@ typing-extensions==4.5.0
     #   pylint
 urllib3==1.26.15
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
     #   responses

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -23,7 +23,6 @@ attrs==22.2.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
-    #   pytest
 babel==2.12.1
     # via sphinx
 bleach==6.0.0
@@ -41,7 +40,7 @@ charset-normalizer==3.1.0
     #   -r requirements/test.txt
     #   aiohttp
     #   requests
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -76,7 +75,7 @@ gitpython==3.1.31
     # via
     #   -r requirements/test.txt
     #   pytest-repo-health
-google-auth==2.17.0
+google-auth==2.17.3
     # via
     #   -r requirements/test.txt
     #   google-auth-oauthlib
@@ -85,7 +84,7 @@ google-auth-oauthlib==1.0.0
     # via
     #   -r requirements/test.txt
     #   gspread
-gspread==5.7.2
+gspread==5.8.0
     # via -r requirements/test.txt
 idna==3.4
     # via
@@ -94,7 +93,7 @@ idna==3.4
     #   yarl
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.1.0
+importlib-metadata==6.3.0
     # via sphinx
 iniconfig==2.0.0
     # via
@@ -134,7 +133,7 @@ pyasn1-modules==0.2.8
     # via
     #   -r requirements/test.txt
     #   google-auth
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   doc8
     #   readme-renderer
@@ -143,7 +142,7 @@ pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-aiohttp

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -12,7 +12,7 @@ packaging==21.3
     # via
     #   -c requirements/constraints.txt
     #   build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyparsing==3.0.9
     # via packaging

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -15,7 +15,7 @@ aiosignal==1.3.1
     #   aiohttp
 asgiref==3.6.0
     # via django
-astroid==2.15.1
+astroid==2.15.2
     # via
     #   pylint
     #   pylint-celery
@@ -27,7 +27,6 @@ attrs==22.2.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
-    #   pytest
 cachetools==5.3.0
     # via
     #   -r requirements/test.txt
@@ -50,7 +49,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -83,7 +82,7 @@ gitpython==3.1.31
     # via
     #   -r requirements/test.txt
     #   pytest-repo-health
-google-auth==2.17.0
+google-auth==2.17.3
     # via
     #   -r requirements/test.txt
     #   google-auth-oauthlib
@@ -92,7 +91,7 @@ google-auth-oauthlib==1.0.0
     # via
     #   -r requirements/test.txt
     #   gspread
-gspread==5.7.2
+gspread==5.8.0
     # via -r requirements/test.txt
 idna==3.4
     # via
@@ -150,7 +149,7 @@ pycodestyle==2.10.0
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   edx-lint
     #   pylint-celery
@@ -168,7 +167,7 @@ pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/test.txt
     #   pytest-aiohttp

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,7 +21,6 @@ attrs==22.2.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
-    #   pytest
 cachetools==5.3.0
     # via
     #   -r requirements/base.txt
@@ -35,7 +34,7 @@ charset-normalizer==3.1.0
     #   -r requirements/base.txt
     #   aiohttp
     #   requests
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via pytest-cov
 dockerfile==3.2.0
     # via -r requirements/base.txt
@@ -58,7 +57,7 @@ gitpython==3.1.31
     # via
     #   -r requirements/base.txt
     #   pytest-repo-health
-google-auth==2.17.0
+google-auth==2.17.3
     # via
     #   -r requirements/base.txt
     #   google-auth-oauthlib
@@ -67,7 +66,7 @@ google-auth-oauthlib==1.0.0
     # via
     #   -r requirements/base.txt
     #   gspread
-gspread==5.7.2
+gspread==5.8.0
     # via -r requirements/base.txt
 idna==3.4
     # via
@@ -109,7 +108,7 @@ pyparsing==3.0.9
     # via
     #   -r requirements/base.txt
     #   packaging
-pytest==7.2.2
+pytest==7.3.0
     # via
     #   -r requirements/base.txt
     #   pytest-aiohttp

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ exclude = .git,.tox,migrations
 max-line-length = 120
 
 [pytest]
-addopts = --cov repo_health --cov-report term-missing
+addopts = --cov repo_health --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements
 testpaths =
     tests


### PR DESCRIPTION
**Description:**
Removes codecov as a dependency since the library is deprecated.

**Merge checklist:**
- [x] Changelog record added
- [x] Commits are squashed
