### PR TITLE
feat: Do not fail on having issues fetching PyPI names.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 
 * Use repo's actual org name in GitHub calls, rather than hardcoded "edx"
 * Remove codecov dependency.
+* Check for PyPI name will no longer fail if it finds too many or too few names.
 
 Added
 =====

--- a/repo_health/check_setup_py.py
+++ b/repo_health/check_setup_py.py
@@ -65,8 +65,8 @@ def check_pypi_name(setup_py, setup_cfg, all_results):
     cfg_names = re.findall(r"""(?m)^name\s?=\s?([\w-]+)""", setup_cfg)
 
     names = py_names + cfg_names
-    if names:
-        assert len(names) == 1
+    # If the name doesn't match the expected format, don't fill it into the results.
+    if names and len(names) == 1:
         all_results[module_dict_key]["pypi_name"] = names[0]
 
 

--- a/tests/test_check_setup_py.py
+++ b/tests/test_check_setup_py.py
@@ -9,6 +9,7 @@ from repo_health.check_setup_py import check_project_urls, check_pypi_name, chec
 
 FAKE_REPO_ROOT = Path(__file__).parent / "fake_repos"
 
+
 @pytest.mark.parametrize("fake_repo, pypi_name", [
     ("kodegail", "kodegail"),
     ("just_setup_py", "some_other_pypi_name"),
@@ -25,6 +26,7 @@ def test_check_pypi_name(fake_repo, pypi_name):
     else:
         assert "pypi_name" not in all_results[module_dict_key]
 
+
 @pytest.mark.parametrize("fake_repo, repo_url", [
     ("just_setup_py", "https://github.com/openedx/just_setup_py"),
     ("just_setup_cfg", "https://github.com/openedx/just_setup_cfg"),
@@ -40,6 +42,7 @@ def test_check_repo_url(fake_repo, repo_url):
         assert all_results[module_dict_key]["repo_url"] == repo_url
     else:
         assert "repo_url" not in all_results[module_dict_key]
+
 
 @pytest.mark.parametrize("fake_repo, project_urls", [
     (


### PR DESCRIPTION
We would like to have the repo health run not fail on data not matching our expected output, such as when there may be multiple names specified. Instead, we just want the output to display an error demonstrating that the data was not valid.

**Description:**

Describe in a couple of sentences what this PR adds

**Merge checklist:**
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
