### PR TITLE
fix: Remove a reference in the test fake repo.

### DIFF
--- a/tests/fake_repos/django_pytest_requirement/requirements/docs.in
+++ b/tests/fake_repos/django_pytest_requirement/requirements/docs.in
@@ -1,5 +1,4 @@
 
 -c constraints.txt
 
-edx-sphinx-theme
 Sphinx


### PR DESCRIPTION
The fake repo referenced the edx-sphinx-theme which is deprecated.
We're removing the reference since it's not valuable to have and might
confuse people about whether or not the deprecated repo is still in use.
