### PR TITLE
build: tag arbi-bom team on upgrade requirements PRs

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -15,11 +15,9 @@ jobs:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
       branch: ${{ github.event.inputs.branch || 'master' }}
-      # optional parameters below; fill in if you'd like github or email notifications
-      # user_reviewers: ""
-      # team_reviewers: ""
-      # email_address: ""
-      # send_success_notification: false
+      team_reviewers: "arbi-bom"
+      email_address: "arbi-bom@edx.org"
+      send_success_notification: false
     secrets:
       requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
       requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
## Description
- Enable tagging `arbi-bom` team for review on the scheduled Python Requirements Upgrade PRs to avoid missing any upgrade PRs. 