### PR TITLE
chore: update renovate check

### DIFF
--- a/tests/test_check_renovate.py
+++ b/tests/test_check_renovate.py
@@ -16,21 +16,33 @@ def get_repo_path(repo_name):
 async def mocked_responses(*args, **kwargs):
     return  "24-4-2016"
 
+async def mocked_total_oldest_pr_response(*args, **kwargs):
+    return  10, "24-4-2023"
 
+@mock.patch('repo_health.check_renovate.get_total_and_oldest_renovate_pull_requests')
 @mock.patch('repo_health.check_renovate.get_last_pull_date')
 @pytest.mark.asyncio
-async def test_check_renovate_true(mock_get):
-    mock_get.return_value = await mocked_responses()
+async def test_check_renovate_true(mock_get_last_pull_date, mock_get_total_and_oldest_renovate_pull_requests):
+    mock_get_last_pull_date.return_value = await mocked_responses()
+    mock_get_total_and_oldest_renovate_pull_requests.return_value = await mocked_total_oldest_pr_response()
     all_results = {MODULE_DICT_KEY: {}}
-    await check_renovate(all_results, repo_path=get_repo_path('renovate_repo1'), github_repo=None)
+    github_repo_mock = mock.AsyncMock()
+    github_repo_mock.return_value = None
+
+    await check_renovate(all_results, repo_path=get_repo_path('renovate_repo1'), github_repo=github_repo_mock())
 
     assert all_results[MODULE_DICT_KEY]['configured'] is True
 
+@mock.patch('repo_health.check_renovate.get_total_and_oldest_renovate_pull_requests')
 @mock.patch('repo_health.check_renovate.get_last_pull_date')
 @pytest.mark.asyncio
-async def test_check_renovate_false(mock_get):
-    mock_get.return_value = await mocked_responses()
+async def test_check_renovate_false(mock_get_last_pull_date, mock_get_total_and_oldest_renovate_pull_requests):
+    mock_get_last_pull_date.return_value = await mocked_responses()
+    mock_get_total_and_oldest_renovate_pull_requests.return_value = await mocked_total_oldest_pr_response()
     all_results = {MODULE_DICT_KEY: {}}
-    await check_renovate(all_results, repo_path=get_repo_path('js_repo'), github_repo=None)
+    github_repo_mock = mock.AsyncMock()
+    github_repo_mock.return_value = None
+
+    await check_renovate(all_results, repo_path=get_repo_path('js_repo'), github_repo=github_repo_mock())
 
     assert all_results[MODULE_DICT_KEY]['configured'] is False


### PR DESCRIPTION
## Ticket
[Add new Renovate repo health checks.](https://github.com/openedx/wg-frontend/issues/170)

## Description:
This PR updates `check_renovate` with the following functionalities:

1. Total number of currently open PRs from Renovate.
2. Creation date of oldest still-open Renovate PR.

**Merge checklist:**
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed
