### PR TITLE
build: extract sqldb generation in repo health job as artifact

### DIFF
--- a/scripts/repo-health-artifact.sh
+++ b/scripts/repo-health-artifact.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e -v
+
+WORKSPACE=$PWD
+
+# Generate sql file from the yaml files
+cd "${WORKSPACE}/individual_repo_data"
+repo_health_dashboard --data-dir . --configuration "${WORKSPACE}/edx-repo-health/repo_health_dashboard/configuration.yaml" \
+    --output-sqlite "${WORKSPACE}/dashboards/dashboard"

--- a/scripts/repo-health-script.sh
+++ b/scripts/repo-health-script.sh
@@ -6,7 +6,6 @@ export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
 WORKSPACE=$PWD
-
 # If the REPORT_DATE variable is set and not an empty string parse the date to standardize it.
 if [[ -n $REPORT_DATE ]]; then 
     REPORT_DATE=$(date '+%Y-%m-%d' -d "$REPORT_DATE")
@@ -129,7 +128,7 @@ failed_repo_names=$(echo "${failed_repos[*]}")
 echo "Pushing data"
 cd "${WORKSPACE}/individual_repo_data"
 repo_health_dashboard --data-dir . --configuration "${WORKSPACE}/edx-repo-health/repo_health_dashboard/configuration.yaml" \
-    --output-csv "${WORKSPACE}/dashboards/dashboard" --output-sqlite "${WORKSPACE}/dashboards/dashboard"
+    --output-csv "${WORKSPACE}/dashboards/dashboard"
 
 cd "${WORKSPACE}"
 # Only commit the data if running with master and no REPORT_DATE is set.


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/openedx/edx-repo-health/issues/405
- This PR modifies the `repo-health-job` script to skip generating the sqlite3 db file which was previously being committed to the repository.
- After this change, a new script `repo-health-artifact` gets triggered to generate sqlite3 db file separately from the yaml files committed to the repository by the `repo health workflow build`. 

## Testing
- The new script has been tested to work successfully in a test build https://github.com/edx/repo-health-data/actions/runs/7085336098
- The sqlite3 db file is being successfully generated as artifact with the job. 