### PR TITLE
chore: Update to the new version of paragon in the new scope.

### DIFF
--- a/tests/fake_repos/js_repo/package.json
+++ b/tests/fake_repos/js_repo/package.json
@@ -10,7 +10,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/frontend-component-footer": "10.0.11",
     "@edx/frontend-platform": "1.9.0",
-    "@edx/paragon": "13.17.3",
+    "@openedx/paragon": "^21.5.7",
     "@fortawesome/fontawesome-svg-core": "1.2.28",
     "@fortawesome/free-brands-svg-icons": "5.11.2",
     "@fortawesome/free-regular-svg-icons": "5.11.2",

--- a/tests/fake_repos/python_js_repo/package.json
+++ b/tests/fake_repos/python_js_repo/package.json
@@ -10,7 +10,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/frontend-component-footer": "10.0.11",
     "@edx/frontend-platform": "1.9.0",
-    "@edx/paragon": "13.17.3",
+    "@openedx/paragon": "^21.5.7",
     "@fortawesome/fontawesome-svg-core": "1.2.28",
     "@fortawesome/free-brands-svg-icons": "5.11.2",
     "@fortawesome/free-regular-svg-icons": "5.11.2",


### PR DESCRIPTION
Part of https://github.com/openedx/axim-engineering/issues/23

This replaces the `@edx/paragon` packag to point to the `paragon` package at
the `openedx` scope(`@openedx/paragon`). Imports have been updated to use the
same locations in the new package.
