### PR TITLE
fix: pin gspread<5.12 to fix repo health job failure

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.8.6
+aiohttp==3.9.0
     # via
     #   github-py
     #   pytest-aiohttp
@@ -16,15 +16,13 @@ attrs==23.1.0
     # via aiohttp
 cachetools==5.3.2
     # via google-auth
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 charset-normalizer==3.3.2
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 dockerfile==3.3.1
     # via -r requirements/base.in
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 frozenlist==1.4.0
     # via
@@ -42,8 +40,10 @@ google-auth==2.23.4
     #   gspread
 google-auth-oauthlib==1.1.0
     # via gspread
-gspread==5.12.0
-    # via -r requirements/base.in
+gspread==5.11.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 idna==3.4
     # via
     #   requests
@@ -62,7 +62,7 @@ packaging==21.3
     #   pytest
 pluggy==1.3.0
     # via pytest
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   pyasn1-modules
     #   rsa
@@ -99,5 +99,5 @@ tomli==2.0.1
     # via pytest
 urllib3==2.1.0
     # via requests
-yarl==1.9.2
+yarl==1.9.3
     # via aiohttp

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -38,5 +38,5 @@ tomli==2.0.1
     #   tox
 tox==4.0.0
     # via -r requirements/ci.in
-virtualenv==20.24.6
+virtualenv==20.24.7
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,3 +14,7 @@
 
 # greater version breaking test.
 packaging==21.3
+
+# gspread==5.12.0 contains breaking changes 
+# which break the scheduled repo health job
+gspread<5.12.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.8.6
+aiohttp==3.9.0
     # via
     #   -r requirements/quality.txt
     #   github-py
@@ -40,7 +40,7 @@ cachetools==5.3.2
     #   -r requirements/quality.txt
     #   google-auth
     #   tox
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/quality.txt
     #   requests
@@ -52,7 +52,6 @@ chardet==5.2.0
 charset-normalizer==3.3.2
     # via
     #   -r requirements/quality.txt
-    #   aiohttp
     #   requests
 click==8.1.7
     # via
@@ -97,7 +96,7 @@ dockerfile==3.3.1
     # via -r requirements/quality.txt
 edx-lint==5.3.6
     # via -r requirements/quality.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -130,8 +129,10 @@ google-auth-oauthlib==1.1.0
     # via
     #   -r requirements/quality.txt
     #   gspread
-gspread==5.12.0
-    # via -r requirements/quality.txt
+gspread==5.11.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
 idna==3.4
     # via
     #   -r requirements/quality.txt
@@ -206,7 +207,7 @@ pluggy==1.3.0
     #   diff-cover
     #   pytest
     #   tox
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   -r requirements/quality.txt
     #   pyasn1-modules
@@ -219,7 +220,7 @@ pycodestyle==2.11.1
     # via -r requirements/quality.txt
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   diff-cover
     #   rich
@@ -366,7 +367,7 @@ urllib3==2.1.0
     #   -r requirements/quality.txt
     #   requests
     #   responses
-virtualenv==20.24.6
+virtualenv==20.24.7
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -374,7 +375,7 @@ wheel==0.41.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-yarl==1.9.2
+yarl==1.9.3
     # via
     #   -r requirements/quality.txt
     #   aiohttp

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,7 @@
 #
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.8.6
+aiohttp==3.9.0
     # via
     #   -r requirements/test.txt
     #   github-py
@@ -35,14 +35,13 @@ cachetools==5.3.2
     # via
     #   -r requirements/test.txt
     #   google-auth
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   requests
 charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
-    #   aiohttp
     #   requests
 coverage[toml]==7.3.2
     # via
@@ -60,7 +59,7 @@ docutils==0.19
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -88,8 +87,10 @@ google-auth-oauthlib==1.1.0
     # via
     #   -r requirements/test.txt
     #   gspread
-gspread==5.12.0
-    # via -r requirements/test.txt
+gspread==5.11.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 idna==3.4
     # via
     #   -r requirements/test.txt
@@ -131,7 +132,7 @@ pluggy==1.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   -r requirements/test.txt
     #   pyasn1-modules
@@ -142,7 +143,7 @@ pyasn1-modules==0.3.0
     #   google-auth
 pydata-sphinx-theme==0.14.3
     # via sphinx-book-theme
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   accessible-pygments
     #   doc8
@@ -241,7 +242,7 @@ urllib3==2.1.0
     #   -r requirements/test.txt
     #   requests
     #   responses
-yarl==1.9.2
+yarl==1.9.3
     # via
     #   -r requirements/test.txt
     #   aiohttp

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.41.3
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3.1
     # via -r requirements/pip.in
-setuptools==68.2.2
+setuptools==69.0.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.8.6
+aiohttp==3.9.0
     # via
     #   -r requirements/test.txt
     #   github-py
@@ -31,14 +31,13 @@ cachetools==5.3.2
     # via
     #   -r requirements/test.txt
     #   google-auth
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   requests
 charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
-    #   aiohttp
     #   requests
 click==8.1.7
     # via
@@ -64,7 +63,7 @@ dockerfile==3.3.1
     # via -r requirements/test.txt
 edx-lint==5.3.6
     # via -r requirements/quality.in
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -92,8 +91,10 @@ google-auth-oauthlib==1.1.0
     # via
     #   -r requirements/test.txt
     #   gspread
-gspread==5.12.0
-    # via -r requirements/test.txt
+gspread==5.11.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 idna==3.4
     # via
     #   -r requirements/test.txt
@@ -137,7 +138,7 @@ pluggy==1.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   -r requirements/test.txt
     #   pyasn1-modules
@@ -244,7 +245,7 @@ urllib3==2.1.0
     #   -r requirements/test.txt
     #   requests
     #   responses
-yarl==1.9.2
+yarl==1.9.3
     # via
     #   -r requirements/test.txt
     #   aiohttp

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.8.6
+aiohttp==3.9.0
     # via
     #   -r requirements/base.txt
     #   github-py
@@ -25,14 +25,13 @@ cachetools==5.3.2
     # via
     #   -r requirements/base.txt
     #   google-auth
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/base.txt
     #   requests
 charset-normalizer==3.3.2
     # via
     #   -r requirements/base.txt
-    #   aiohttp
     #   requests
 coverage[toml]==7.3.2
     # via
@@ -40,7 +39,7 @@ coverage[toml]==7.3.2
     #   pytest-cov
 dockerfile==3.3.1
     # via -r requirements/base.txt
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -r requirements/base.txt
     #   pytest
@@ -68,8 +67,10 @@ google-auth-oauthlib==1.1.0
     # via
     #   -r requirements/base.txt
     #   gspread
-gspread==5.12.0
-    # via -r requirements/base.txt
+gspread==5.11.3
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 idna==3.4
     # via
     #   -r requirements/base.txt
@@ -97,7 +98,7 @@ pluggy==1.3.0
     # via
     #   -r requirements/base.txt
     #   pytest
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   -r requirements/base.txt
     #   pyasn1-modules
@@ -163,7 +164,7 @@ urllib3==2.1.0
     #   -r requirements/base.txt
     #   requests
     #   responses
-yarl==1.9.2
+yarl==1.9.3
     # via
     #   -r requirements/base.txt
     #   aiohttp


### PR DESCRIPTION
## Description
- Latest version `gspread==5.12.0` contains breaking changes which broke the scheduled repo health job five days ago. 
- There have been some fixes merged in the upstream repo but the new version hasn't been released yet. 
- Pinning the package version for now in order to resume the scheduled repo health job functionality. 