### PR TITLE
Remove tox-battery

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.9.0
+aiohttp==3.9.1
     # via
     #   github-py
     #   pytest-aiohttp
@@ -34,7 +34,7 @@ github-py @ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f
     # via -r requirements/github.in
 gitpython==3.1.40
     # via pytest-repo-health
-google-auth==2.23.4
+google-auth==2.24.0
     # via
     #   google-auth-oauthlib
     #   gspread
@@ -44,7 +44,7 @@ gspread==5.11.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-idna==3.4
+idna==3.6
     # via
     #   requests
     #   yarl

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -38,5 +38,5 @@ tomli==2.0.1
     #   tox
 tox==4.0.0
     # via -r requirements/ci.in
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via tox

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,4 +7,3 @@
 
 diff-cover                # Changeset diff test coverage
 rich                      # Fancy formatting for console dashboards
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,8 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.9.0
-aiohttp==3.9.0
+aiohttp==3.9.1
     # via
     #   -r requirements/quality.txt
     #   github-py
@@ -41,7 +40,6 @@ cachetools==5.3.2
     #   -r requirements/quality.txt
     #   google-auth
     #   tox
-certifi==2023.11.17
 certifi==2023.11.17
     # via
     #   -r requirements/quality.txt
@@ -99,7 +97,6 @@ dockerfile==3.3.1
 edx-lint==5.3.6
     # via -r requirements/quality.txt
 exceptiongroup==1.2.0
-exceptiongroup==1.2.0
     # via
     #   -r requirements/quality.txt
     #   pytest
@@ -123,7 +120,7 @@ gitpython==3.1.40
     # via
     #   -r requirements/quality.txt
     #   pytest-repo-health
-google-auth==2.23.4
+google-auth==2.24.0
     # via
     #   -r requirements/quality.txt
     #   google-auth-oauthlib
@@ -136,12 +133,12 @@ gspread==5.11.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/quality.txt
     #   requests
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==6.9.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
@@ -210,7 +207,6 @@ pluggy==1.3.0
     #   diff-cover
     #   pytest
     #   tox
-pyasn1==0.5.1
 pyasn1==0.5.1
     # via
     #   -r requirements/quality.txt
@@ -354,11 +350,7 @@ tomlkit==0.12.3
     #   -r requirements/quality.txt
     #   pylint
 tox==4.0.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.1
-    # via -r requirements/dev.in
+    # via -r requirements/ci.txt
 typing-extensions==4.8.0
     # via
     #   -r requirements/quality.txt
@@ -371,15 +363,14 @@ urllib3==2.1.0
     #   -r requirements/quality.txt
     #   requests
     #   responses
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.41.3
+wheel==0.42.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-yarl==1.9.3
 yarl==1.9.3
     # via
     #   -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,8 +6,7 @@
 #
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-aiohttp==3.9.0
-aiohttp==3.9.0
+aiohttp==3.9.1
     # via
     #   -r requirements/test.txt
     #   github-py
@@ -37,7 +36,6 @@ cachetools==5.3.2
     #   -r requirements/test.txt
     #   google-auth
 certifi==2023.11.17
-certifi==2023.11.17
     # via
     #   -r requirements/test.txt
     #   requests
@@ -62,7 +60,6 @@ docutils==0.19
     #   restructuredtext-lint
     #   sphinx
 exceptiongroup==1.2.0
-exceptiongroup==1.2.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -81,7 +78,7 @@ gitpython==3.1.40
     # via
     #   -r requirements/test.txt
     #   pytest-repo-health
-google-auth==2.23.4
+google-auth==2.24.0
     # via
     #   -r requirements/test.txt
     #   google-auth-oauthlib
@@ -94,14 +91,14 @@ gspread==5.11.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
     #   yarl
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.8.0
+importlib-metadata==6.9.0
     # via sphinx
 iniconfig==2.0.0
     # via
@@ -136,7 +133,6 @@ pluggy==1.3.0
     #   -r requirements/test.txt
     #   pytest
 pyasn1==0.5.1
-pyasn1==0.5.1
     # via
     #   -r requirements/test.txt
     #   pyasn1-modules
@@ -145,7 +141,7 @@ pyasn1-modules==0.3.0
     # via
     #   -r requirements/test.txt
     #   google-auth
-pydata-sphinx-theme==0.14.3
+pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
 pygments==2.17.2
     # via
@@ -246,7 +242,6 @@ urllib3==2.1.0
     #   -r requirements/test.txt
     #   requests
     #   responses
-yarl==1.9.3
 yarl==1.9.3
     # via
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==6.8.0
+importlib-metadata==6.9.0
     # via build
 packaging==21.3
     # via
@@ -25,7 +25,7 @@ tomli==2.0.1
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-wheel==0.41.3
+wheel==0.42.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.9.0
+aiohttp==3.9.1
     # via
     #   -r requirements/test.txt
     #   github-py
@@ -82,7 +82,7 @@ gitpython==3.1.40
     # via
     #   -r requirements/test.txt
     #   pytest-repo-health
-google-auth==2.23.4
+google-auth==2.24.0
     # via
     #   -r requirements/test.txt
     #   google-auth-oauthlib
@@ -95,7 +95,7 @@ gspread==5.11.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.9.0
+aiohttp==3.9.1
     # via
     #   -r requirements/base.txt
     #   github-py
@@ -58,7 +58,7 @@ gitpython==3.1.40
     # via
     #   -r requirements/base.txt
     #   pytest-repo-health
-google-auth==2.23.4
+google-auth==2.24.0
     # via
     #   -r requirements/base.txt
     #   google-auth-oauthlib
@@ -71,7 +71,7 @@ gspread==5.11.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-idna==3.4
+idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests


### PR DESCRIPTION
**Description:**

tox-battery is preventing us from upgrading tox.  It only did one thing, and tox 4 now does that automatically.

**Merge checklist:**
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
