### PR TITLE
Read toml using path not file content

### DIFF
--- a/repo_health/utils.py
+++ b/repo_health/utils.py
@@ -103,10 +103,8 @@ def find_version_in_toml(version_type, repo_dir, version):
     repo_dir: repository path
     version: version to look for
     """
-    # Read the pyproject.toml file
-    pyproject_toml_file_path = os.path.join(repo_dir, "pyproject.toml")
     try:
-        data = toml.load(get_file_content(pyproject_toml_file_path))
+        data = toml.load(os.path.join(repo_dir, "pyproject.toml"))
         classifiers = data.get('project', {}).get('classifiers', [])
         if version_type == "python":
             return any(f"Programming Language :: Python :: {version}" in classifier for classifier in classifiers)


### PR DESCRIPTION
toml.load function read toml file and converts into dict, it take both content and file path and decides. But In our case we were passing file content but due to some reasons in the content it was considering it a file so now we are reading it using file name so that load function always use path to read file, I tested it on local.

Error build: https://github.com/edx/repo-health-data/actions/runs/7298483488/job/19889543897#step:10:783