### PR TITLE
fix: downgraded the setuptools to v70

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,13 +15,18 @@
 # greater version breaking test.
 packaging==21.3
 
-# gspread==5.12.0 contains breaking changes 
+# gspread==5.12.0 contains breaking changes
 # which break the scheduled repo health job
 gspread<5.12.0
 
 # pytest==8.1.0 breaks test plugin [needs to be investigated separately]
 pytest<8.1.0
 
-# Needed for Python 3.12 compatibility. 
+# Needed for Python 3.12 compatibility.
 # Can be removed once support for Python<3.12 is dropped.
 backports-zoneinfo==0.2.1; python_version < "3.9"
+
+# date added: 13-09-24
+# setuptools > 70.3.0 breaks the repo health workflow link: https://github.com/edx/repo-health-data/actions/runs/10846619044/job/30103106806
+# Issue to remove the pin https://github.com/openedx/edx-repo-health/issues/523
+setuptools==70.3.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.44.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via -r requirements/pip.in
-setuptools==74.1.2
+setuptools==70.3.0
     # via -r requirements/pip.in


### PR DESCRIPTION
**Description:**

`setuptools` update from `v69` to `v70` broke the `repo-health-workflow`. The link to the broken workflow is [mentioned here](https://github.com/edx/repo-health-data/actions/runs/10846619044/job/30103106806). This PR downgrades the setuptools so workflow can be successful. 

Issue to resolve issue regarding the setuptools upgrade: https://github.com/openedx/edx-repo-health/issues/523
