### PR TITLE
docs: add arbi-bom team as maintainer

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,6 +13,6 @@ metadata:
   annotations:
     openedx.org/arch-interest-groups: ""
 spec:
-  owner: group:2u-arch-bom
+  owner: group:2u-arbi-bom
   type: 'other'
   lifecycle: 'production'


### PR DESCRIPTION
## Description
- As per the discussion in Maintenance working group, `arbi-bom` team will maintain this repo from now on. 