### PR TITLE
chore: bump checkout version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4
     - name: Setup Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
## Description
- Bumping the version of `actions/checkout@v4` 