### PR TITLE
Add support for python 3.11 and 3.12 | Drop support for python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.12']
+        python-version: ['3.11', '3.12']
         toxenv: [python, quality]
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,14 @@ Unreleased
 **********
 
 
+[2.0.0] - 2025-05-07
+********************
+
+Added
+=====
+* Added support for ``Python 3.11`` and dropped support for ``Python 3.8``
+
+
 [1.1.0] - 2024-03-06
 ********************
 

--- a/repo_health/__init__.py
+++ b/repo_health/__init__.py
@@ -12,7 +12,7 @@ from configparser import ConfigParser
 import dockerfile
 import pytest
 
-__version__ = "1.1.1"
+__version__ = "2.0.0"
 
 
 def parse_config_file(path):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,9 +16,9 @@ attrs==25.3.0
     # via aiohttp
 cachetools==5.5.2
     # via google-auth
-certifi==2025.1.31
+certifi==2025.4.26
     # via requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 dockerfile==3.4.0
     # via -r requirements/base.in
@@ -29,10 +29,10 @@ frozenlist==1.6.0
 gitdb==4.0.12
     # via gitpython
 github-py @ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/github.in
+    # via -r requirements/github.in
 gitpython==3.1.44
     # via pytest-repo-health
-google-auth==2.39.0
+google-auth==2.40.0
     # via
     #   google-auth-oauthlib
     #   gspread
@@ -40,7 +40,7 @@ google-auth-oauthlib==1.2.2
     # via gspread
 gspread==5.11.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
 idna==3.10
     # via
@@ -56,7 +56,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 packaging==21.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   pytest
 pluggy==1.5.0
     # via pytest
@@ -74,7 +74,7 @@ pyparsing==3.2.3
     # via packaging
 pytest==8.0.2
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   pytest-aiohttp
     #   pytest-asyncio
     #   pytest-repo-health
@@ -84,7 +84,7 @@ pytest-asyncio==0.23.8
     # via
     #   -r requirements/base.in
     #   pytest-aiohttp
-pytest-repo-health==3.1.0
+pytest-repo-health==3.2.0
     # via -r requirements/base.in
 pyyaml==6.0.2
     # via
@@ -102,7 +102,7 @@ toml==0.10.2
     # via -r requirements/base.in
 urllib3==2.2.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   requests
 yarl==1.20.0
     # via aiohttp

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -18,7 +18,7 @@ filelock==3.18.0
     #   virtualenv
 packaging==21.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   pyproject-api
     #   tox
 platformdirs==4.3.7
@@ -33,5 +33,5 @@ pyproject-api==1.5.0
     # via tox
 tox==4.0.0
     # via -r requirements/ci.in
-virtualenv==20.30.0
+virtualenv==20.31.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,350 +6,350 @@
 #
 aiohappyeyeballs==2.6.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   aiohttp
 aiohttp==3.11.18
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   github-py
     #   pytest-aiohttp
 aiosignal==1.3.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   aiohttp
 asgiref==3.8.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   django
 astroid==3.3.9
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   aiohttp
 build==1.2.2.post1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
 cachetools==5.5.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   google-auth
     #   tox
-certifi==2025.1.31
+certifi==2025.4.26
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests
 chardet==5.2.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   diff-cover
     #   tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests
 click==8.1.8
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/pip-tools.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/quality.txt
     #   click-log
     #   code-annotations
     #   edx-lint
     #   pip-tools
 click-log==0.4.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 colorama==0.4.6
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   tox
 coverage[toml]==7.8.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pytest-cov
 diff-cover==9.2.4
     # via -r requirements/dev.in
 dill==0.4.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
 distlib==0.3.9
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   virtualenv
 django==4.2.20
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/quality.txt
 dockerfile==3.4.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    # via -r requirements/quality.txt
 edx-lint==5.6.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    # via -r requirements/quality.txt
 filelock==3.18.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   tox
     #   virtualenv
 frozenlist==1.6.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   aiohttp
     #   aiosignal
 gitdb==4.0.12
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   gitpython
 github-py @ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    # via -r requirements/quality.txt
 gitpython==3.1.44
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pytest-repo-health
-google-auth==2.39.0
+google-auth==2.40.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   google-auth-oauthlib
     #   gspread
 google-auth-oauthlib==1.2.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   gspread
 gspread==5.11.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests
     #   yarl
 iniconfig==2.1.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pytest
 isort==6.0.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   jinja2
 mccabe==0.7.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.4.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
 oauthlib==3.2.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests-oauthlib
 packaging==21.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/pip-tools.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/quality.txt
     #   build
     #   pyproject-api
     #   pytest
     #   tox
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   stevedore
 pip-tools==7.4.1
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/pip-tools.txt
+    # via -r requirements/pip-tools.txt
 platformdirs==4.3.7
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   pylint
     #   tox
     #   virtualenv
 pluggy==1.5.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   diff-cover
     #   pytest
     #   tox
 propcache==0.3.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   google-auth
 pycodestyle==2.13.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    # via -r requirements/quality.txt
 pydocstyle==6.3.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    # via -r requirements/quality.txt
 pygments==2.19.1
     # via
     #   diff-cover
     #   rich
-pylint==3.3.6
+pylint==3.3.7
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 pylint-django==2.6.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 pylint-plugin-utils==0.8.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
 pyparsing==3.2.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/pip-tools.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/quality.txt
     #   packaging
 pyproject-api==1.5.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   tox
 pyproject-hooks==1.2.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
 pytest==8.0.2
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/quality.txt
     #   pytest-aiohttp
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-repo-health
 pytest-aiohttp==1.1.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pytest-repo-health
 pytest-asyncio==0.23.8
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pytest-aiohttp
 pytest-cov==6.1.1
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
-pytest-repo-health==3.1.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    # via -r requirements/quality.txt
+pytest-repo-health==3.2.0
+    # via -r requirements/quality.txt
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   code-annotations
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   code-annotations
     #   pytest-repo-health
     #   responses
 requests==2.32.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   requests-oauthlib
     #   responses
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   google-auth-oauthlib
 responses==0.25.7
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    # via -r requirements/quality.txt
 rich==14.0.0
     # via -r requirements/dev.in
 rsa==4.9.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   google-auth
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   edx-lint
 smmap==5.0.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   gitdb
 snowballstemmer==2.2.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pydocstyle
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   code-annotations
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   python-slugify
 toml==0.10.2
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    # via -r requirements/quality.txt
 tomlkit==0.13.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pylint
 tox==4.0.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
+    # via -r requirements/ci.txt
 urllib3==2.2.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/quality.txt
     #   requests
     #   responses
-virtualenv==20.30.0
+virtualenv==20.31.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/ci.txt
+    #   -r requirements/ci.txt
     #   tox
 wheel==0.45.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
 yarl==1.20.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,22 +8,22 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 aiohappyeyeballs==2.6.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
 aiohttp==3.11.18
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   github-py
     #   pytest-aiohttp
 aiosignal==1.3.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
 alabaster==0.7.16
     # via sphinx
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
 babel==2.17.0
     # via
@@ -33,24 +33,24 @@ beautifulsoup4==4.13.4
     # via pydata-sphinx-theme
 cachetools==5.5.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth
-certifi==2025.1.31
+certifi==2025.4.26
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 coverage[toml]==7.8.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
 doc8==1.1.2
     # via -r requirements/doc.in
 dockerfile==3.4.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
 docutils==0.21.2
     # via
     #   doc8
@@ -60,42 +60,42 @@ docutils==0.21.2
     #   sphinx
 frozenlist==1.6.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   aiosignal
 gitdb==4.0.12
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   gitpython
 github-py @ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
 gitpython==3.1.44
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-repo-health
-google-auth==2.39.0
+google-auth==2.40.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth-oauthlib
     #   gspread
 google-auth-oauthlib==1.2.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   gspread
 gspread==5.11.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
     #   yarl
 imagesize==1.4.1
     # via sphinx
 iniconfig==2.1.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 jinja2==3.1.6
     # via sphinx
@@ -103,19 +103,19 @@ markupsafe==3.0.2
     # via jinja2
 multidict==6.4.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   yarl
 nh3==0.2.21
     # via readme-renderer
 oauthlib==3.2.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests-oauthlib
 packaging==21.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
@@ -123,21 +123,21 @@ pbr==6.1.1
     # via stevedore
 pluggy==1.5.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 propcache==0.3.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   yarl
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
@@ -150,56 +150,56 @@ pygments==2.19.1
     #   sphinx
 pyparsing==3.2.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   packaging
 pytest==8.0.2
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
     #   pytest-aiohttp
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-repo-health
 pytest-aiohttp==1.1.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-repo-health
 pytest-asyncio==0.23.8
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-aiohttp
 pytest-cov==6.1.1
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
-pytest-repo-health==3.1.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
+pytest-repo-health==3.2.0
+    # via -r requirements/test.txt
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-repo-health
     #   responses
 readme-renderer==44.0
     # via -r requirements/doc.in
 requests==2.32.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests-oauthlib
     #   responses
     #   sphinx
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth-oauthlib
 responses==0.25.7
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
 rsa==4.9.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth
 smmap==5.0.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   gitdb
 snowballstemmer==2.2.0
     # via sphinx
@@ -227,20 +227,20 @@ sphinxcontrib-serializinghtml==2.0.0
 stevedore==5.4.1
     # via doc8
 toml==0.10.2
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
 typing-extensions==4.13.2
     # via
     #   beautifulsoup4
     #   pydata-sphinx-theme
 urllib3==2.2.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test.txt
     #   requests
     #   responses
 yarl==1.20.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.1.8
     # via pip-tools
 packaging==21.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,9 +10,9 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
 setuptools==70.3.0
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,16 +6,16 @@
 #
 aiohappyeyeballs==2.6.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
 aiohttp==3.11.18
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   github-py
     #   pytest-aiohttp
 aiosignal==1.3.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
 asgiref==3.8.1
     # via django
@@ -25,19 +25,19 @@ astroid==3.3.9
     #   pylint-celery
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
 cachetools==5.5.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth
-certifi==2025.1.31
+certifi==2025.4.26
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 click==8.1.8
     # via
@@ -50,54 +50,54 @@ code-annotations==2.3.0
     # via edx-lint
 coverage[toml]==7.8.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
 dill==0.4.0
     # via pylint
 django==4.2.20
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/quality.in
 dockerfile==3.4.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
 edx-lint==5.6.0
     # via -r requirements/quality.in
 frozenlist==1.6.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   aiosignal
 gitdb==4.0.12
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   gitpython
 github-py @ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
 gitpython==3.1.44
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-repo-health
-google-auth==2.39.0
+google-auth==2.40.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth-oauthlib
     #   gspread
 google-auth-oauthlib==1.2.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   gspread
 gspread==5.11.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
     #   yarl
 iniconfig==2.1.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 isort==6.0.1
     # via
@@ -111,17 +111,17 @@ mccabe==0.7.0
     # via pylint
 multidict==6.4.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   yarl
 oauthlib==3.2.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests-oauthlib
 packaging==21.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
     #   pytest
 pbr==6.1.1
     # via stevedore
@@ -129,27 +129,27 @@ platformdirs==4.3.7
     # via pylint
 pluggy==1.5.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 propcache==0.3.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   yarl
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth
 pycodestyle==2.13.0
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==3.3.6
+pylint==3.3.7
     # via
     #   edx-lint
     #   pylint-celery
@@ -165,56 +165,56 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pyparsing==3.2.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   packaging
 pytest==8.0.2
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
     #   pytest-aiohttp
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-repo-health
 pytest-aiohttp==1.1.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-repo-health
 pytest-asyncio==0.23.8
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-aiohttp
 pytest-cov==6.1.1
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
-pytest-repo-health==3.1.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
+pytest-repo-health==3.2.0
+    # via -r requirements/test.txt
 python-slugify==8.0.4
     # via code-annotations
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   pytest-repo-health
     #   responses
 requests==2.32.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests-oauthlib
     #   responses
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth-oauthlib
 responses==0.25.7
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
 rsa==4.9.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   google-auth
 six==1.17.0
     # via edx-lint
 smmap==5.0.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   gitdb
 snowballstemmer==2.2.0
     # via pydocstyle
@@ -225,18 +225,18 @@ stevedore==5.4.1
 text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    # via -r requirements/test.txt
 tomlkit==0.13.2
     # via pylint
 urllib3==2.2.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test.txt
     #   requests
     #   responses
 yarl==1.20.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/test.txt
+    #   -r requirements/test.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,163 +6,163 @@
 #
 aiohappyeyeballs==2.6.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   aiohttp
 aiohttp==3.11.18
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   github-py
     #   pytest-aiohttp
 aiosignal==1.3.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   aiohttp
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   aiohttp
 cachetools==5.5.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   google-auth
-certifi==2025.1.31
+certifi==2025.4.26
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 coverage[toml]==7.8.0
     # via pytest-cov
 dockerfile==3.4.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    # via -r requirements/base.txt
 frozenlist==1.6.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   aiosignal
 gitdb==4.0.12
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   gitpython
 github-py @ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    # via -r requirements/base.txt
 gitpython==3.1.44
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   pytest-repo-health
-google-auth==2.39.0
+google-auth==2.40.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   google-auth-oauthlib
     #   gspread
 google-auth-oauthlib==1.2.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   gspread
 gspread==5.11.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
     #   yarl
 iniconfig==2.1.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   pytest
 multidict==6.4.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   yarl
 oauthlib==3.2.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests-oauthlib
 packaging==21.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
     #   pytest
 pluggy==1.5.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   pytest
 propcache==0.3.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   aiohttp
     #   yarl
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   google-auth
 pyparsing==3.2.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   packaging
 pytest==8.0.2
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
     #   pytest-aiohttp
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-repo-health
 pytest-aiohttp==1.1.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   pytest-repo-health
 pytest-asyncio==0.23.8
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   pytest-aiohttp
 pytest-cov==6.1.1
     # via -r requirements/test.in
-pytest-repo-health==3.1.0
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+pytest-repo-health==3.2.0
+    # via -r requirements/base.txt
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   pytest-repo-health
     #   responses
 requests==2.32.3
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests-oauthlib
     #   responses
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   google-auth-oauthlib
 responses==0.25.7
     # via -r requirements/test.in
 rsa==4.9.1
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   google-auth
 smmap==5.0.2
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   gitdb
 toml==0.10.2
-    # via -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    # via -r requirements/base.txt
 urllib3==2.2.3
     # via
-    #   -c /home/runner/work/edx-repo-health/edx-repo-health/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/base.txt
     #   requests
     #   responses
 yarl==1.20.0
     # via
-    #   -r /home/runner/work/edx-repo-health/edx-repo-health/requirements/base.txt
+    #   -r requirements/base.txt
     #   aiohttp

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
     include_package_data=True,
     install_requires=load_requirements("requirements/base.in"),
     packages=["repo_health_dashboard", "repo_health_dashboard.utils"],
-    python_requires=">=3.8",
+    python_requires=">=3.11",
     license="Apache Software License 2.0",
     zip_safe=False,
     keywords="Django edx",
@@ -119,7 +119,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],
     entry_points={


### PR DESCRIPTION
- resolves: https://github.com/openedx/edx-repo-health/issues/521
---
- drop support for python versions older than 3.11
- upgrade requirements
